### PR TITLE
Relative URL support

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -95,15 +95,15 @@ class ShokoCommonAgent:
 
         if len(series['art']['banner']):
             for art in series['art']['banner']:
-                metadata.banner[art['url']] = Proxy.Media(HTTP.Request(art['url']).content, art['index'])
+                metadata.banner[art['url']] = Proxy.Media(HTTP.Request("http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art['url'])).content, art['index'])
 
         if len(series['art']['thumb']):
             for art in series['art']['thumb']:
-                metadata.posters[art['url']] = Proxy.Media(HTTP.Request(art['url']).content, art['index'])
+                metadata.posters[art['url']] = Proxy.Media(HTTP.Request("http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art['url'])).content, art['index'])
 
         if len(series['art']['fanart']):
             for art in series['art']['fanart']:
-                metadata.art[art['url']] = Proxy.Media(HTTP.Request(art['url']).content, art['index'])
+                metadata.art[art['url']] = Proxy.Media(HTTP.Request("http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art['url'])).content, art['index'])
 
         ### Generate general content ratings.
         ### VERY rough approximation to: https://www.healthychildren.org/English/family-life/Media/Pages/TV-Ratings-A-Guide-for-Parents.aspx

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -153,7 +153,7 @@ class ShokoCommonAgent:
 
                 if len(series['art']['thumb']):
                     for art in series['art']['thumb']:
-                        episodeObj.thumbs[art['url']] = Proxy.Media(HTTP.Request(art['url']).content, art['index'])
+                        episodeObj.thumbs[art['url']] = Proxy.Media(HTTP.Request("http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art['url'])).content, art['index'])
 
 
 def try_get(arr, idx, default=""):


### PR DESCRIPTION
Small change to the image fetching code after  ShokoAnime/ShokoServer@fa7bd75083ce4f1cb8b34423cc9d8da30647095b was merged to return relative URLs via the API.

I've tested this locally and it looks to work OK, _however_ my Shoko library currently only has Posters in it so i've not been able to verify if Banners, Backgrounds and Episode Thumbnails also work.