### PR TITLE
Relative URL support

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -152,14 +152,14 @@ class ShokoCommonAgent:
 
                 if len(series['art']['thumb']):
                     for art in series['art']['thumb']:
-                        episodeObj.thumbs[art['url']] = Proxy.Media(HTTP.Request(art['url']).content, art['index'])
+                        episodeObj.thumbs[art['url']] = Proxy.Media(HTTP.Request("http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art['url'])).content, art['index'])
 
     def metadata_add(self, meta, images):
         valid = list()
         
         for art in images:
             Log("[metadata_add] :: Adding metadata %s (index %d)" % (art['url'], art['index']))
-            meta[art['url']] = Proxy.Media(HTTP.Request(art['url']).content, art['index'])
+            meta[art['url']] = Proxy.Media(HTTP.Request("http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art['url'])).content, art['index'])
             valid.append(art['url'])
 
         meta.validate_keys(valid)


### PR DESCRIPTION
Small change to the image fetching code after  ShokoAnime/ShokoServer@fa7bd75083ce4f1cb8b34423cc9d8da30647095b was merged to return relative URLs via the API.

I've tested this locally and it looks to work OK, _however_ my Shoko library currently only has Posters in it so i've not been able to verify if Banners, Backgrounds and Episode Thumbnails also work.