### PR TITLE
Fixes

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -163,15 +163,17 @@ class ShokoCommonAgent:
 
         if not movie:
             for ep in series['eps']:
-                if ep['eptype'] != "Episode":
+                if ep['eptype'] != "Episode" and ep['eptype'] != "Special":
                     continue
 
-                season = 1
+                if ep['eptype'] == "Episode": season = 1
+                elif ep['eptype'] == "Special": season = 0
                 try:
                     season = int(ep['season'].split('x')[0])
+                    if season <= 0 and ep['eptype'] == 'Episode': season = 1
                 except:
                     pass
-
+                
                 episodeObj = metadata.seasons[season].episodes[ep['epnumber']]
                 episodeObj.title = ep['name']
                 episodeObj.summary = ep['summary']

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -163,14 +163,17 @@ class ShokoCommonAgent:
 
         if not movie:
             for ep in series['eps']:
-                if ep['eptype'] != "Episode" and ep['eptype'] != "Special":
+                if ep['eptype'] != "Episode" and ep['eptype'] != "Special" and ep['eptype'] != "Credits" and ep['eptype'] != "Trailer":
                     continue
 
                 if ep['eptype'] == "Episode": season = 1
                 elif ep['eptype'] == "Special": season = 0
+                elif ep['eptype'] == "Credits": season = -1
+                elif ep['eptype'] == "Trailer": season = -2;
                 try:
                     season = int(ep['season'].split('x')[0])
                     if season <= 0 and ep['eptype'] == 'Episode': season = 1
+                    elif season > 0 and ep['eptype'] == 'Special': season = 0
                 except:
                     pass
                 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -74,7 +74,7 @@ class ShokoCommonAgent:
 
         # http://127.0.0.1:8111/api/serie/search?query=Clannad&level=1&apikey=d422dfd2-bdc3-4219-b3bb-08b85aa65579
 
-        prelimresults = HttpReq("api/serie/search?query=%s&level=%d&fuzzy=%d" % (urllib.quote(name), 1, Prefs['Fuzzy']))
+        prelimresults = HttpReq("api/serie/search?query=%s&level=%d&fuzzy=%d" % (urllib.quote(name.encode('utf8')), 1, Prefs['Fuzzy']))
 
         for result in prelimresults:
             #for result in group['series']:
@@ -238,7 +238,7 @@ class ShokoTVAgent(Agent.TV_Shows, ShokoCommonAgent):
 
 class ShokoMovieAgent(Agent.Movies, ShokoCommonAgent):
     name, primary_provider, fallback_agent, contributes_to, languages, accepts_from = (
-        'ShokoMovies', True, False, ['com.plexapp.agents.hama'], [Locale.Language.English, ],
+        'ShokoMovies', True, False, ['com.plexapp.agents.hama'], [Locale.Language.English, 'fr', 'zh', 'sv', 'no', 'da', 'fi', 'nl', 'de', 'it', 'es', 'pl', 'hu', 'el', 'tr', 'ru', 'he', 'ja', 'pt', 'cs', 'ko', 'sl', 'hr'],
         ['com.plexapp.agents.localmedia'])  # , 'com.plexapp.agents.opensubtitles'
 
     def search(self, results, media, lang, manual): self.Search(results, media, lang, manual, True)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -163,7 +163,7 @@ class ShokoCommonAgent:
 
         if not movie:
             for ep in series['eps']:
-                if ep['eptype'] != "Episode" and ep['eptype'] != "Special" and ep['eptype'] != "Credits" and ep['eptype'] != "Trailer":
+                if ep['eptype'] not in ["Episode", "Special", "Credits", "Trailer"]:
                     continue
 
                 if ep['eptype'] == "Episode": season = 1
@@ -176,7 +176,7 @@ class ShokoCommonAgent:
                     elif season > 0 and ep['eptype'] == 'Special': season = 0
                 except:
                     pass
-                
+
                 episodeObj = metadata.seasons[season].episodes[ep['epnumber']]
                 episodeObj.title = ep['name']
                 episodeObj.summary = ep['summary']

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -126,6 +126,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
             else:
                 seasonNumber = int(seasonStr.split('x')[0])
                 if seasonNumber <= 0 and episode_data['eptype'] == 'Episode': seasonNumber = 1
+                elif seasonNumber > 0 and episode_data['eptype'] == 'Special': seasonNumber = 0
             
             if seasonNumber <= 0 and Prefs['IncludeOther'] == False: continue #Ignore this by choice.
             

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -109,11 +109,10 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
             # http://127.0.0.1:8111/api/ep/getbyfilename?apikey=d422dfd2-bdc3-4219-b3bb-08b85aa65579&filename=%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
 
             episode_data = HttpReq("api/ep/getbyfilename?filename=%s" % (urllib.quote(os.path.basename(file))))
-            if len(episode_data) == 0: break
-            if (try_get(episode_data, "code", 200) == 404): break
+            if len(episode_data) == 0: continue
+            if (try_get(episode_data, "code", 200) == 404): continue
 
             series_data = HttpReq("api/serie/fromep?id=%d&nocast=1&notag=1" % episode_data['id'])
-            if (series_data["ismovie"] == 1): break # Ignore movies in preference for Shoko Movie Scanner
             showTitle = series_data['name'].encode("utf-8") #no idea why I need to do this.
             Log.info('show title: %s', showTitle)
 
@@ -128,9 +127,9 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 seasonNumber = int(seasonStr.split('x')[0])
                 if seasonNumber <= 0 and episode_data['eptype'] == 'Episode': seasonNumber = 1
             
-            if seasonNumber <= 0 and Prefs['IncludeOther'] == False: break #Ignore this by choice.
+            if seasonNumber <= 0 and Prefs['IncludeOther'] == False: continue #Ignore this by choice.
             
-            
+            if (series_data["ismovie"] == 1 and seasonNumber >= 1): continue # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
             Log.info('season number: %s', seasonNumber)
             episodeNumber = int(episode_data['epnumber'])
             Log.info('episode number: %s', episodeNumber)

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -119,20 +119,23 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
 
             seasonNumber = 0
             seasonStr = try_get(episode_data, 'season', None)
-            if seasonStr == None:
+            if episode_data['eptype'] == 'Credits': seasonNumber = -1 #season -1 for OP/ED
+            elif episode_data['eptype'] == 'Trailer': seasonNumber = -2 #season -2 for Trailer
+            elif seasonStr == None:
                 if episode_data['eptype'] == 'Episode': seasonNumber = 1
-                if episode_data['eptype'] == 'Credits': seasonNumber = -1 #season -1 for OP/ED
+                elif episode_data['eptype'] == 'Special': seasonNumber = 0
             else:
-                seasonNumber = seasonStr.split('x')[0]
-
+                seasonNumber = int(seasonStr.split('x')[0])
+                if seasonNumber <= 0 and episode_data['eptype'] == 'Episode': seasonNumber = 1
+            
             if seasonNumber <= 0 and Prefs['IncludeOther'] == False: break #Ignore this by choice.
-                
-
+            
+            
             Log.info('season number: %s', seasonNumber)
             episodeNumber = int(episode_data['epnumber'])
             Log.info('episode number: %s', episodeNumber)
-
-            vid = Media.Episode(showTitle, int(seasonNumber), episodeNumber)
+            
+            vid = Media.Episode(showTitle, seasonNumber, episodeNumber)
             Log.info('vid: %s', vid)
             vid.parts.append(file)
             mediaList.append(vid)


### PR DESCRIPTION
Add trailers as season -2.
ShokoMovies support metadata other than English.
Move ShokeMovies' trailers, specials, and credits to ShokoTV.
Fix encoding when searching anime title match (happens on Japanese titles).
Add metadata info for Trailers and OP/ED.