### PR TITLE
Apiv3

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -45,7 +45,7 @@ def GetApiKey():
         data = json.dumps({
             'user': Prefs['Username'],
             'pass': Prefs['Password'] if Prefs['Password'] != None else '',
-            'device': 'hoko Metadata For Plex'
+            'device': 'Shoko Metadata For Plex'
         })
         resp = HttpPost('api/auth', data)['apikey']
         Log.Debug('Got API KEY: %s' % resp)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -6,6 +6,7 @@ import thread
 import threading
 import urllib
 import copy
+import json
 from urllib2 import HTTPError
 from datetime import datetime
 from lxml import etree
@@ -13,16 +14,25 @@ from lxml import etree
 API_KEY = ''
 PLEX_HOST = ''
 
+EpisodeType = {
+    'Episode': 1,
+    'Credits': 2,
+    'Special': 3,
+    'Trailer': 4,
+    'Parody': 5,
+    'Other': 6
+}
+
 #this is from https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/master/Contents/Code/__init__.py
 THEME_URL = 'http://tvthemes.plexapp.com/%s.mp3'
-LINK_REGEX = r"https?:\/\/\w+.\w+(?:\/?\w+)? \[([^\]]+)\]"
+LINK_REGEX = r'https?:\/\/\w+.\w+(?:\/?\w+)? \[([^\]]+)\]'
 
 def ValidatePrefs():
     pass
 
 
 def Start():
-    Log("Shoko metata agent started")
+    Log('Shoko metata agent started')
     HTTP.Headers['Accept'] = 'application/json'
     HTTP.CacheTime = 0.1 #cache, can you please go away, typically we will be requesting LOCALLY. HTTP.CacheTime
     ValidatePrefs()
@@ -32,10 +42,13 @@ def GetApiKey():
     global API_KEY
 
     if not API_KEY:
-        data = '{"user":"%s", "pass":"%s", "device":"%s"}' % (
-            Prefs['Username'], Prefs['Password'] if Prefs['Password'] != None else '', 'Shoko Metadata For Plex')
+        data = json.dumps({
+            'user': Prefs['Username'],
+            'pass': Prefs['Password'] if Prefs['Password'] != None else '',
+            'device': 'hoko Metadata For Plex'
+        })
         resp = HttpPost('api/auth', data)['apikey']
-        Log.Debug("Got API KEY: %s" % resp)
+        Log.Debug('Got API KEY: %s' % resp)
         API_KEY = resp
         return resp
 
@@ -51,14 +64,16 @@ def HttpPost(url, postdata):
 
 def HttpReq(url, authenticate=True, retry=True):
     global API_KEY
-    Log("Requesting: %s" % url)
-    api_string = ''
+    Log('Requesting: %s' % url)
+    
+    myheaders = {}
+
     if authenticate:
-        api_string = '&apikey=%s' % GetApiKey()
+        myheaders['apikey'] = GetApiKey()
 
     try:
         return JSON.ObjectFromString(
-            HTTP.Request('http://%s:%s/%s%s' % (Prefs['Hostname'], Prefs['Port'], url, api_string)).content)
+            HTTP.Request('http://%s:%s/%s' % (Prefs['Hostname'], Prefs['Port'], url), headers=myheaders).content)
     except Exception, e:
         if not retry:
             raise e
@@ -72,51 +87,126 @@ class ShokoCommonAgent:
     def Search(self, results, media, lang, manual, movie):
         name = ( media.title if movie else media.show )
 
-        # http://127.0.0.1:8111/api/serie/search?query=Clannad&level=1&apikey=d422dfd2-bdc3-4219-b3bb-08b85aa65579
-
         if movie:
             if media.filename:
-                filename = os.path.basename(urllib.unquote(media.filename))
+                filename = urllib.unquote(media.filename)
 
-                episode_data = HttpReq("api/ep/getbyfilename?filename=%s" % (urllib.quote(filename.encode('utf8'))))
-                movie_data = HttpReq("api/serie/fromep?id=%s" % (episode_data['id']))
+                Log('Searching movie %s - %s' % (name, filename))
 
-                score = 100 if movie_data['name'] == name else 85  # TODO: Improve this to respect synonyms./
-                title = movie_data['name'] + ' - ' + episode_data['name']
-                meta = MetadataSearchResult('%s' % (episode_data['id']), title, try_get(episode_data, 'year', None), score, lang)
+                # Get file data using filename
+                # http://127.0.0.1:8111/api/v3/File/PathEndsWith/%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
+                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % filename)
+
+                # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
+                if len(file_data) > 1:
+                    Log('File search has more than 1 result. HOW DID YOU DO IT?')
+                file_data = file_data[0]
+
+                # Get series data
+                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
+                series_data = {}
+                series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
+                series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
+
+                # Get episode data
+                ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][0]['ID'] # Taking the first
+                ep_data = {}
+                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+
+                # Make a dict of language -> title for all titles in anidb data
+                ep_titles = {}
+                for item in ep_data['anidb']['Titles']:
+                    ep_titles[item['Language']] = item['Name']
+
+                # Get episode title according to the preference
+                title = None
+                for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
+                    lang = lang.strip()
+                    title = ep_titles[lang.upper()]
+                    if title is not None: break
+                if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                full_title = series_data['shoko']['Name'] + ' - ' + title
+
+                # Get year from air date
+                air_date = try_get(ep_data['anidb'], 'AirDate', None)
+                year = air_date.split('-')[0] if air_date is not None else None
+
+                score = 100 if series_data['shoko']['Name'] == name else 85  # TODO: Improve this to respect synonyms./
+
+                meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
                 results.Append(meta)
 
             else: # For manual searches
-                prelimresults = HttpReq("api/serie/search?query=%s&level=%d&fuzzy=%d&ismovie=1" % (urllib.quote(name.encode('utf8')), 2, Prefs['Fuzzy']))
+
+                Log('Searching movie %s' % name)
+
+                # Search for series using the name
+                prelimresults = HttpReq('api/v3/Series/Search/%s' % urllib.quote(name.encode('utf8'))) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad
 
                 for result in prelimresults:
-                    for episode in result['eps']:
-                        title = result['name'] + ' - ' + episode['name']
+                    # Get episode list using series ID
+                    episodes = HttpReq('api/v3/Series/%s/Episode' % result['IDs']['ID']) # http://127.0.0.1:8111/api/v3/Series/212/Episode
+
+                    for episode in episodes:
+                        # Get episode data
+                        ep_id = episode['IDs']['ID']
+                        ep_data = {}
+                        ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+
+                        # Get series data
+                        series_data = {}
+                        series_data['shoko'] = HttpReq('api/v3/Episode/%s/Series' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/Series
+
+                        # Make a dict of language -> title for all titles in anidb data
+                        ep_titles = {}
+                        for item in ep_data['anidb']['Titles']:
+                            ep_titles[item['Language']] = item['Name']
+
+                        # Get episode title according to the preference
+                        title = None
+                        for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
+                            lang = lang.strip()
+                            title = ep_titles[lang.upper()]
+                            if title is not None: break
+                        if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                        full_title = series_data['shoko']['Name'] + ' - ' + title
+
+                        # Get year from air date
+                        air_date = try_get(ep_data['anidb'], 'AirDate', None)
+                        year = air_date.split('-')[0] if air_date is not None else None
+
                         if title == name: score = 100 # Check if full name matches (Series name + episode name)
-                        elif result['name'] == name: score = 90 # Check if series name matches
+                        elif result['Name'] == name: score = 90 # Check if series name matches
                         else: score = 80
-                        meta = MetadataSearchResult('%s' % (episode['id']), title, try_get(episode, 'year', None), score, lang)
+
+                        meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
                         results.Append(meta)
 
         else:
-            prelimresults = HttpReq("api/serie/search?query=%s&level=%d&fuzzy=%d" % (urllib.quote(name.encode('utf8')), 1, Prefs['Fuzzy']))
+            # Search for series using the name
+            prelimresults = HttpReq('api/v3/Series/Search/%s' % urllib.quote(name.encode('utf8'))) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad
 
             for result in prelimresults:
-                #for result in group['series']:
-                score = 100 if result['name'] == name else 85  # TODO: Improve this to respect synonyms./
-                meta = MetadataSearchResult('%s' % result['id'], result['name'], try_get(result, 'year', None), score, lang)
+                # Get series data
+                series_id = result['IDs']['ID']
+                series_data = {}
+                series_data['shoko'] = result # Just to make it uniform across every place it's used
+                series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id)
+
+                # Get year from air date
+                air_date = try_get(series_data['anidb'], 'AirDate', None)
+                year = air_date.split('-')[0] if air_date is not None else None
+
+                score = 100 if series_data['shoko']['Name'] == name else 85  # TODO: Improve this to respect synonyms./
+
+                meta = MetadataSearchResult(str(series_id), series_data['shoko']['Name'], year, score, lang)
                 results.Append(meta)
 
                 # results.Sort('score', descending=True)
 
     def Update(self, metadata, media, lang, force, movie):
-        Log("update(%s)" % metadata.id)
+        Log('Updating %s' % metadata.id)
         aid = metadata.id
-        # title = media.name
-        # http://127.0.0.1:8111/api/ep/getbyfilename?apikey=d422dfd2-bdc3-4219-b3bb-08b85aa65579&filename=%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
-
-        # episode_data = HttpReq("api/ep/getbyfilename?apikey=%s&filename=%s" % (GetApiKey(), urllib.quote(media.filename)))
-
 
         flags = 0
         flags = flags | Prefs['hideMiscTags']       << 0 #0b00001 : Hide AniDB Internal Tags
@@ -126,61 +216,92 @@ class ShokoCommonAgent:
         flags = flags | Prefs['hideSpoilerTags']    << 4 #0b10000 : Hide Plot Spoiler Tags
 
         if movie:
-            series = HttpReq("api/serie/fromep?id=%s&level=3&allpics=1&tagfilter=%d" % (aid, flags))
-            movie_episode_data = HttpReq("api/ep?id=%s" % (aid))
-            aid = try_get(series, 'id', None)
-            if not aid:
-                Log('Error! Series not found.')
-                return
+            # Get series data
+            series_data = {}
+            series_data['shoko'] = HttpReq('api/v3/Episode/%s/Series' % aid) # http://127.0.0.1:8111/api/v3/Series/24
+            series_id = series_data['shoko']['IDs']['ID']
+            series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
-            if movie_episode_data['name'] == 'Complete Movie':
-                movie_name = series['name']
-                movie_sort_name = series['name']
+            # Get episode data
+            ep_data = {}
+            ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % (aid)) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+
+            aid = series_id # Change aid to series ID
+
+            # Make a dict of language -> title for all titles in anidb data
+            ep_titles = {}
+            for item in ep_data['anidb']['Titles']:
+                ep_titles[item['Language']] = item['Name']
+
+            title = try_get(ep_titles, 'EN', None)
+            if title in ['Complete Movie', 'Web']:
+                movie_name = series_data['anidb']['Name']
+                movie_sort_name = series_data['anidb']['Name']
             else:
-                movie_name = series['name'] + ' - ' + movie_episode_data['name']
-                movie_sort_name = series['name'] + ' - ' + str(movie_episode_data['epnumber']).zfill(3)
+                # Get episode title according to the preference
+                title = None
+                for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
+                    lang = lang.strip()
+                    title = ep_titles[lang.upper()]
+                    if title is not None: break
+                if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                movie_name = series_data['shoko']['Name'] + ' - ' + title
+                movie_sort_name = series_data['shoko']['Name'] + ' - ' + str(ep_data['anidb']['EpisodeNumber']).zfill(3)
 
-            metadata.summary = summary_sanitizer(try_get(series, 'summary'))
+            Log('Movie Title: %s' % movie_name)
+
+            metadata.summary = summary_sanitizer(try_get(series_data['anidb'], 'Description'))
             metadata.title = movie_name
             metadata.title_sort = movie_sort_name
-            metadata.rating = float(movie_episode_data['rating'])
-            year = try_get(movie_episode_data, "year", try_get(series, "year", None))
+            metadata.rating = float(ep_data['anidb']['Rating']['Value']/100)
+            
+            # Get year from air date
+            air_date = try_get(ep_data['anidb'], 'AirDate', None)
+            year = air_date.split('-')[0] if air_date is not None else None
 
             if year:
                 metadata.year = int(year)
 
+            if air_date is not None:
+                metadata.originally_available_at = datetime.strptime(air_date, '%Y-%m-%d').date()
+
         else:
-            series = HttpReq("api/serie?id=%s&level=3&allpics=1&tagfilter=%d" % (aid, flags))
+            # Get series data
+            series_data = {}
+            series_data['shoko'] = HttpReq('api/v3/Series/%s' % aid) # http://127.0.0.1:8111/api/v3/Series/24
+            series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % aid) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
-            metadata.summary = summary_sanitizer(try_get(series, 'summary'))
-            metadata.title = series['name']
-            metadata.rating = float(series['rating'])
+            Log('Series Title: %s' % series_data['shoko']['Name'])
 
+            metadata.summary = summary_sanitizer(try_get(series_data['anidb'], 'Description'))
+            metadata.title = series_data['shoko']['Name']
+            metadata.rating = float(series_data['anidb']['Rating']['Value']/100)
 
-        tags = []
-        for tag in try_get(series, 'tags', []):
-            tags.append(tag)
+            # Get air date
+            air_date = try_get(series_data['anidb'], 'AirDate', None)
+            if air_date is not None:
+                metadata.originally_available_at = datetime.strptime(air_date, '%Y-%m-%d').date()
 
+        # Get series tags
+        series_tags = HttpReq('api/v3/Series/%s/Tags/%d' % (aid, flags)) # http://127.0.0.1:8111/api/v3/Series/24/Tags/0
+        tags = [tag['Name'] for tag in series_tags]
         metadata.genres = tags
 
-        self.metadata_add(metadata.banners, try_get(series['art'], 'banner', []))
-        self.metadata_add(metadata.posters, try_get(series['art'], 'thumb', []))
-        self.metadata_add(metadata.art, try_get(series['art'], 'fanart', []))
+        # Get images
+        images = try_get(series_data['shoko'], 'Images', {})
+        self.metadata_add(metadata.banners, try_get(images, 'Banners', []))
+        self.metadata_add(metadata.posters, try_get(images, 'Posters', []))
+        self.metadata_add(metadata.art, try_get(images, 'Fanarts', []))
 
-        groupinfo = HttpReq("api/serie/groups?id=%s&level=2" % aid);
-        collections = []
-        for group in groupinfo:
-            if (len(group['series']) > 1):
-                collections.append(group['name'])
-
-        metadata.collections = collections
-
+        # Get group
+        groupinfo = HttpReq('api/v3/Series/%s/Group' % aid)
+        metadata.collections = [groupinfo['Name']] if groupinfo['Size'] > 1 else []
 
 
         ### Generate general content ratings.
         ### VERY rough approximation to: https://www.healthychildren.org/English/family-life/Media/Pages/TV-Ratings-A-Guide-for-Parents.aspx
 
-        if Prefs["Ratings"]:
+        if Prefs['Ratings']:
             if 'Kodomo' in tags:
                 metadata.content_rating = 'TV-Y'
 
@@ -207,81 +328,102 @@ class ShokoCommonAgent:
 
             Log('Assumed tv rating to be: %s' % metadata.content_rating)
 
-        airdate = try_get(series, 'air', '1/01/0001 12:00:00 AM')
-        if airdate != '1/01/0001 12:00:00 AM' and airdate != '0001-01-01':
-            metadata.originally_available_at = datetime.strptime(airdate, "%Y-%m-%d").date()
-
+        # Get cast
+        cast = HttpReq('api/v3/Series/%s/Cast' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast
         metadata.roles.clear()
-        for role in try_get(series, 'roles', []):
+        Log('Cast')
+        for role in cast:
             meta_role = metadata.roles.new()
-            Log(role['character'])
-            meta_role.name = role['staff']
-            meta_role.role = role['character']
-            meta_role.photo = "http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=role['staff_image'])
+            meta_role.name = role['Staff']['Name']
+            meta_role.role = role['Character']['Name']
+            Log('%s - %s' % (meta_role.role, meta_role.name))
+            image = role['Staff']['Image']
+            meta_role.photo = 'http://{host}:{port}/api/v3/Image/{source}/{type}/{id}'.format(host=Prefs['Hostname'], port=Prefs['Port'], source=image['Source'], type=image['Type'], id=image['ID'])
 
 
         if not movie:
-            for ep in series['eps']:
-                if ep['eptype'] not in ["Episode", "Special", "Credits", "Trailer"]:
+            # Get episode list using series ID
+            episodes = HttpReq('api/v3/Series/%s/Episode' % aid) # http://127.0.0.1:8111/api/v3/Series/212/Episode
+
+            for episode in episodes:
+                # Get episode data
+                ep_id = episode['IDs']['ID']
+                ep_data = {}
+                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id)
+                ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id)
+
+                ep_type = ep_data['anidb']['Type']
+                if ep_type not in [1, 3, 2, 4]: # Episode, Special, Credits, Trailer
                     continue
 
-                if ep['eptype'] == "Episode": season = 1
-                elif ep['eptype'] == "Special": season = 0
-                elif ep['eptype'] == "Credits": season = -1
-                elif ep['eptype'] == "Trailer": season = -2
-                if not Prefs['SingleSeasonOrdering']:
-                    try:
-                        season = int(ep['season'].split('x')[0])
-                        if season <= 0 and ep['eptype'] == 'Episode': season = 1
-                        elif season > 0 and ep['eptype'] == 'Special': season = 0
-                    except:
-                        pass
+                # Get season number
+                season = 0
+                if ep_type == EpisodeType['Episode']: season = 1
+                elif ep_type == EpisodeType['Special']: season = 0
+                elif ep_type == EpisodeType['Credits']: season = -1
+                elif ep_type == EpisodeType['Trailer']: season = -2
+                if not Prefs['SingleSeasonOrdering'] and len(ep_data['tvdb']) != 0:
+                    ep_data['tvdb'] = ep_data['tvdb'][0] # Take the first link, as explained before
+                    season = ep_data['tvdb']['Season']
+                    if season <= 0 and ep_type == EpisodeType['Episode']: season = 1
+                    elif season > 0 and ep_type == EpisodeType['Special']: season = 0
 
-                episodeObj = metadata.seasons[season].episodes[ep['epnumber']]
-                episodeObj.title = ep['name']
-                if (ep['summary'] != "Episode Overview not Available"): 
-                    episodeObj.summary = summary_sanitizer(ep['summary'])
-                Log("" + str(ep['epnumber']) + ": " + ep['summary'])
+                Log('Season: %s', season)
+                Log('Episode: %s', ep_data['anidb']['EpisodeNumber'])
 
-                airdate = try_get(ep, 'air', '1/01/0001 12:00:00 AM')
+                episode_obj = metadata.seasons[season].episodes[ep_data['anidb']['EpisodeNumber']]
 
-                if airdate != '1/01/0001 12:00:00 AM' and airdate != '0001-01-01':
-                    episodeObj.originally_available_at = datetime.strptime(airdate, "%Y-%m-%d").date()
+                # Make a dict of language -> title for all titles in anidb data
+                ep_titles = {}
+                for item in ep_data['anidb']['Titles']:
+                    ep_titles[item['Language']] = item['Name']
 
-                if len(ep['art']['thumb']) and Prefs['customThumbs']:
-                    self.metadata_add(episodeObj.thumbs, ep['art']['thumb'])
+                # Get episode title according to the preference
+                title = None
+                for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
+                    lang = lang.strip()
+                    title = ep_titles[lang.upper()]
+                    if title is not None: break
+                if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                episode_obj.title = title
 
-            links = HttpReq("api/links/serie?id=%s" % aid)
+                # Get description
+                if try_get(ep_data['anidb'], 'Description') != 'Episode Overview not Available':
+                    episode_obj.summary = summary_sanitizer(try_get(ep_data['anidb'], 'Description'))
+                    Log('Description: %s' % episode_obj.summary)
+
+                # Get air date
+                air_date = try_get(ep_data['anidb'], 'AirDate', None)
+                if air_date is not None:
+                    episode_obj.originally_available_at = datetime.strptime(air_date, '%Y-%m-%d').date()
+
+                if Prefs['customThumbs'] and 'Thumbnail' in ep_data['tvdb']:
+                   self.metadata_add(episode_obj.thumbs, [ep_data['tvdb']['Thumbnail']])
 
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
-            if Prefs["themeMusic"]:
-                for tid in links["tvdb"]:
+            if Prefs['themeMusic']:
+                for tid in try_get(series_data['shoko']['IDs'], 'TvDB', []):
                     if THEME_URL % tid not in metadata.themes:
                         try:
                             metadata.themes[THEME_URL % tid] = Proxy.Media(HTTP.Request(THEME_URL % tid))
-                            Log("added: %s" % THEME_URL % tid)
+                            Log('added: %s' % THEME_URL % tid)
                         except:
-                            Log("error adding music, probably not found")
+                            Log('error adding music, probably not found')
 
     def metadata_add(self, meta, images):
         valid = list()
         
+        art_url = '' # Declaring it inside the loop throws UnboundLocalError for some reason
         for art in images:
             try:
-                if 'support/plex_404.png' in art['url']:
-                    continue
-                if 'Static/plex_404.png' in art['url']:
-                    continue
-                if ':' in art['url']:
-                    urlparts = urllib.parse.urlparse(art['url'])
-                    art['url'] = art['url'].replace("{scheme}://{host}:{port}/".format(scheme=urlparts.scheme, host=urlparts.hostname, port=urlparts.port), '')
-                url = "http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art['url'])
+                art_url = '/api/v3/Image/{source}/{type}/{id}'.format(source=art['Source'], type=art['Type'], id=art['ID'])
+                url = 'http://{host}:{port}{relativeURL}'.format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art_url)
                 idx = try_get(art, 'index', 0)
-                Log("[metadata_add] :: Adding metadata %s (index %d)" % (url, idx))
-                meta[art['url']] = Proxy.Media(HTTP.Request(url).content, idx)
-                valid.append(art['url'])
+                Log('[metadata_add] :: Adding metadata %s (index %d)' % (url, idx))
+                meta[art_url] = Proxy.Media(HTTP.Request(url).content, idx)
+                valid.append(art_url)
             except Exception as e:
-                Log("[metadata_add] :: Invalid URL given (%s), skipping" % art['url'])
+                Log('[metadata_add] :: Invalid URL given (%s), skipping' % art_url)
                 Log(e)
 
         meta.validate_keys(valid)
@@ -291,17 +433,17 @@ class ShokoCommonAgent:
                 del meta[key]
 
 def summary_sanitizer(summary):
-    if Prefs["synposisCleanLinks"]:
+    if Prefs['synposisCleanLinks']:
         summary = re.sub(LINK_REGEX, r'\1', summary)                                           # Replace links
-    if Prefs["synposisCleanMiscLines"]:
-        summary = re.sub(r'^(\*|--|~) .*',              "",      summary, flags=re.MULTILINE)  # Remove the line if it starts with ('* ' / '-- ' / '~ ')
-    if Prefs["synposisRemoveSummary"]:
-        summary = re.sub(r'\n(Source|Note|Summary):.*', "",      summary, flags=re.DOTALL)     # Remove all lines after this is seen
-    if Prefs["synposisCleanMultiEmptyLines"]:
+    if Prefs['synposisCleanMiscLines']:
+        summary = re.sub(r'^(\*|--|~) .*',              '',      summary, flags=re.MULTILINE)  # Remove the line if it starts with ('* ' / '-- ' / '~ ')
+    if Prefs['synposisRemoveSummary']:
+        summary = re.sub(r'\n(Source|Note|Summary):.*', '',      summary, flags=re.DOTALL)     # Remove all lines after this is seen
+    if Prefs['synposisCleanMultiEmptyLines']:
         summary = re.sub(r'\n\n+',                      r'\n\n', summary, flags=re.DOTALL)     # Condense multiple empty lines
-    return summary.strip(" \n")
+    return summary.strip(' \n')
 
-def try_get(arr, idx, default=""):
+def try_get(arr, idx, default=''):
     try:
         return arr[idx]
     except:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -28,7 +28,7 @@
         "type": "text",
         "default": "8111"
     },
-
+    
     {
         "id": "SingleSeasonOrdering",
         "label": "Use single season ordering (IMPORTANT: Make sure the setting in scanner matches with this!)",
@@ -37,10 +37,10 @@
     },
 
     {
-        "id": "Fuzzy",
-        "label": "Use fuzzy searching in Shoko for matching the titles.",
-        "type": "bool",
-        "default": true
+        "id": "EpisodeTitleLanguagePreference",
+        "label": "The preferred languages for episode titles, separated by a comma",
+        "type": "text",
+        "default": "EN, X-JAT"
     },
 
     {

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -28,18 +28,18 @@ LogFileList = FileListLogger.info
 
 def set_logging(instance, filename):
   global RootLogger, RootHandler, RootFormatting, FileListLogger, FileListHandler, FileListFormatting
-  logger, handler, formatting, backup_count = [RootLogger, RootHandler, RootFormatting, 9] if instance=="Root" else [FileListLogger, FileListHandler, FileListFormatting, 1]
+  logger, handler, formatting, backup_count = [RootLogger, RootHandler, RootFormatting, 9] if instance=='Root' else [FileListLogger, FileListHandler, FileListFormatting, 1]
   if handler: logger.removeHandler(handler)
   handler = logging.handlers.RotatingFileHandler(os.path.join(LOG_PATH, filename), maxBytes=10*1024*1024, backupCount=backup_count)    #handler = logging.FileHandler(os.path.join(LOG_PATH, filename), mode)
   #handler.setFormatter(formatting)
   handler.setLevel(logging.DEBUG)
   logger.addHandler(handler)
-  if instance=="Root":  RootHandler     = handler
+  if instance=='Root':  RootHandler     = handler
   else:                 FileListHandler = handler
 
-### Check config files on boot up then create library variables ###    #platform = xxx if callable(getattr(sys,'platform')) else ""
+### Check config files on boot up then create library variables ###    #platform = xxx if callable(getattr(sys,'platform')) else ''
 import inspect
-LOG_PATH = os.path.abspath(os.path.join(os.path.dirname(inspect.getfile(inspect.currentframe())), "..", "..", "Logs"))
+LOG_PATH = os.path.abspath(os.path.join(os.path.dirname(inspect.getfile(inspect.currentframe())), '..', '..', 'Logs'))
 if not os.path.isdir(LOG_PATH):
   path_location = { 'Windows': '%LOCALAPPDATA%\\Plex Media Server',
                     'MacOSX':  '$HOME/Library/Application Support/Plex Media Server',
@@ -47,7 +47,7 @@ if not os.path.isdir(LOG_PATH):
   try:  path = os.path.expandvars(path_location[Platform.OS.lower()] if Platform.OS.lower() in path_location else '~')  # Platform.OS:  Windows, MacOSX, or Linux
   except: pass #os.makedirs(LOG_PATH)  # User folder on MacOS-X
 LOG_FILE_LIBRARY = LOG_FILE = 'Shoko Metadata Movie Scanner.log'                # Log filename library will include the library name, LOG_FILE not and serve as reference
-set_logging("Root", LOG_FILE_LIBRARY)
+set_logging('Root', LOG_FILE_LIBRARY)
 
 
 def HttpPost(url, postdata):
@@ -59,7 +59,7 @@ def HttpPost(url, postdata):
 
 def HttpReq(url, authenticate=True, retry=True):
     global API_KEY
-    Log.info("Requesting: %s", url)
+    Log.info('Requesting: %s', url)
     api_string = ''
     if authenticate:
         api_string = '&apikey=%s' % GetApiKey()
@@ -81,10 +81,13 @@ def GetApiKey():
     global API_KEY
 
     if not API_KEY:
-        data = '{"user":"%s", "pass":"%s", "device":"%s"}' % (
-            Prefs['Username'], Prefs['Password'] if Prefs['Password'] != None else '', 'Shoko Series Scanner For Plex')
+        data = json.dumps({
+            'user': Prefs['Username'],
+            'pass': Prefs['Password'] if Prefs['Password'] != None else '',
+            'device': 'Shoko Movie Scanner For Plex'
+        })
         resp = HttpPost('api/auth', data)['apikey']
-        Log.info( "Got API KEY: %s", resp)
+        Log.info( 'Got API KEY: %s', resp)
         API_KEY = resp
         return resp
 
@@ -92,45 +95,110 @@ def GetApiKey():
 
 
 def Scan(path, files, mediaList, subdirs, language=None, root=None):
-
     Log.debug('path: %s', path)
     Log.debug('files: %s', files)
-    Log.debug('subdirs: %s', subdirs)
-
-    # Scan for video files.
-    VideoFiles.Scan(path, files, mediaList, subdirs, root)
     
-    for idx, file in enumerate(files):
-        try:
-            Log.info('file: %s', file)
-            # http://127.0.0.1:8111/api/ep/getbyfilename?apikey=d422dfd2-bdc3-4219-b3bb-08b85aa65579&filename=%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
+    for subdir in subdirs:
+        Log.info('[folder] ' + os.path.relpath(subdir, root))
 
-            episode_data = HttpReq("api/ep/getbyfilename?filename=%s" % (urllib.quote(os.path.basename(file))))
-            if len(episode_data) == 0: continue
-            if (try_get(episode_data, "code", 200) == 404): continue
+    if files:
 
-            series_data = HttpReq("api/serie/fromep?id=%d&nocast=1&notag=1" % episode_data['id'])
-            if not (try_get(series_data, "ismovie", 0)) or (episode_data['eptype'] != 'Episode'): continue # Skip series and extras
-            showTitle = series_data['name'].encode("utf-8") #no idea why I need to do this.
-            Log.info('show title: %s', showTitle)
+        # Scan for video files.
+        VideoFiles.Scan(path, files, mediaList, subdirs, root)
+        
+        for idx, file in enumerate(files):
+            try:
+                Log.info('File: %s', file)
 
-            seasonYear = episode_data['year']
-            Log.info('season year: %s', seasonYear)
+                # Get file data using filename
+                # http://127.0.0.1:8111/api/v3/File/PathEndsWith/Clannad/%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
+                file = os.path.join(os.path.split(os.path.dirname(file))[-1], os.path.basename(file)) # Parent folder + file name
+                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(file)))
+                if len(file_data) == 0: continue # Skip if file data is not found
 
-            vid = Media.Movie(showTitle, int(seasonYear))
-            Log.info('vid: %s', vid)
-            vid.parts.append(file)
-            mediaList.append(vid)
-        except Exception as e:
-            Log.error("Error in Scan: '%s'" % e)
-            continue
+                # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
+                if len(file_data) > 1:
+                    Log.info('File search has more than 1 result. HOW DID YOU DO IT?')
+                file_data = file_data[0]
 
-    Log.info('Scan', 'stack media')
-    Stack.Scan(path, files, mediaList, subdirs)
-    Log.info('Scan', 'media list %s', mediaList)
+                # Ignore unrecognized files
+                if 'SeriesIDs' not in file_data:
+                    Log.info('Unrecognized file. Skipping!')
+                    continue
 
+                # Get series data
+                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
+                series_data = {}
+                series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
+                series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
-def try_get(arr, idx, default=""):
+                # Get preferred/overriden title. Preferred title is the one shown in Desktop.
+                show_title = series_data['shoko']['Name'].encode('utf-8') #no idea why I need to do this.
+                Log.info('Show Title: %s', show_title)
+
+                # Get episode data
+                ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][0]['ID'] # Taking the first link, again
+                ep_data = {}
+                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+
+                # Get year from air date
+                air_date = try_get(ep_data['anidb'], 'AirDate', None)
+                season_year = air_date.split('-')[0] if air_date is not None else None
+                Log.info('season year: %s', season_year)
+
+                vid = Media.Movie(show_title, int(season_year))
+                Log.info('vid: %s', vid)
+                vid.parts.append(file)
+                mediaList.append(vid)
+            except Exception as e:
+                Log.error('Error in Scan: "%s"' % e)
+                continue
+
+        Stack.Scan(path, files, mediaList, subdirs)
+
+    if not path: # If current folder is root folder
+        Log.info('Manual call to group folders')
+        subfolders = subdirs[:]
+
+        while subfolders: # subfolder scanning queue
+            full_path = subfolders.pop(0)
+            path = os.path.relpath(full_path, root)
+
+            reverse_path = list(reversed(path.split(os.sep)))
+            
+            Log.info('=' * 100)
+            Log.info('Started subfolder scan: %s', full_path)
+            Log.info('=' * 100)
+
+            subdir_dirs, subdir_files = [], []
+
+            for file in os.listdir(full_path):
+                path_item = os.path.join(full_path, file) 
+                if os.path.isdir(path_item):
+                    subdir_dirs.append(path_item)
+                else:
+                    subdir_files.append(path_item)
+
+            Log.info('Sub-directories: %s', subdir_dirs)
+            Log.info('Files: %s', subdir_files)
+
+            for dir in subdir_dirs:
+                Log.info('[Added for scanning] ' + dir) # Add the subfolder to subfolder scanning queue)
+                subfolders.append(dir)
+
+            grouping_dir = full_path.rsplit(os.sep, full_path.count(os.sep)-1-root.count(os.sep))[0]
+            if subdir_files and (len(reverse_path)>1 or subdir_dirs):
+                if grouping_dir in subdirs:
+                    subdirs.remove(grouping_dir)  #Prevent group folders from being called by Plex normal call to Scan()
+                Log.info('CALLING SCAN FOR FILES IN CURRENT FOLDER')
+                Scan(path, sorted(subdir_files), mediaList, [], language, root) 
+                # relative path for dir or it will group multiple series into one as before and no empty subdirs array because they will be scanned afterwards.
+            
+            Log.info('=' * 100)
+            Log.info('Completed subfolder scan: %s', full_path)
+            Log.info('=' * 100)
+
+def try_get(arr, idx, default=''):
     try:
         return arr[idx]
     except:

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -15,6 +15,15 @@ Prefs = {
 
 API_KEY = ''
 
+EpisodeType = {
+    'Episode': 1,
+    'Credits': 2,
+    'Special': 3,
+    'Trailer': 4,
+    'Parody': 5,
+    'Other': 6
+}
+
 ### Log + LOG_PATH calculated once for all calls ###
 import logging, logging.handlers                        #
 RootLogger     = logging.getLogger('main')
@@ -31,18 +40,18 @@ LogFileList = FileListLogger.info
 
 def set_logging(instance, filename):
   global RootLogger, RootHandler, RootFormatting, FileListLogger, FileListHandler, FileListFormatting
-  logger, handler, formatting, backup_count = [RootLogger, RootHandler, RootFormatting, 9] if instance=="Root" else [FileListLogger, FileListHandler, FileListFormatting, 1]
+  logger, handler, formatting, backup_count = [RootLogger, RootHandler, RootFormatting, 9] if instance=='Root' else [FileListLogger, FileListHandler, FileListFormatting, 1]
   if handler: logger.removeHandler(handler)
   handler = logging.handlers.RotatingFileHandler(os.path.join(LOG_PATH, filename), maxBytes=10*1024*1024, backupCount=backup_count)    #handler = logging.FileHandler(os.path.join(LOG_PATH, filename), mode)
   #handler.setFormatter(formatting)
   handler.setLevel(logging.DEBUG)
   logger.addHandler(handler)
-  if instance=="Root":  RootHandler     = handler
+  if instance=='Root':  RootHandler     = handler
   else:                 FileListHandler = handler
 
-### Check config files on boot up then create library variables ###    #platform = xxx if callable(getattr(sys,'platform')) else ""
+### Check config files on boot up then create library variables ###    #platform = xxx if callable(getattr(sys,'platform')) else ''
 import inspect
-LOG_PATH = os.path.abspath(os.path.join(os.path.dirname(inspect.getfile(inspect.currentframe())), "..", "..", "Logs"))
+LOG_PATH = os.path.abspath(os.path.join(os.path.dirname(inspect.getfile(inspect.currentframe())), '..', '..', 'Logs'))
 if not os.path.isdir(LOG_PATH):
   path_location = { 'Windows': '%LOCALAPPDATA%\\Plex Media Server',
                     'MacOSX':  '$HOME/Library/Application Support/Plex Media Server',
@@ -50,7 +59,7 @@ if not os.path.isdir(LOG_PATH):
   try:  path = os.path.expandvars(path_location[Platform.OS.lower()] if Platform.OS.lower() in path_location else '~')  # Platform.OS:  Windows, MacOSX, or Linux
   except: pass #os.makedirs(LOG_PATH)  # User folder on MacOS-X
 LOG_FILE_LIBRARY = LOG_FILE = 'Shoko Metadata Scanner.log'                # Log filename library will include the library name, LOG_FILE not and serve as reference
-set_logging("Root", LOG_FILE_LIBRARY)
+set_logging('Root', LOG_FILE_LIBRARY)
 
 
 def HttpPost(url, postdata):
@@ -62,15 +71,15 @@ def HttpPost(url, postdata):
 
 def HttpReq(url, authenticate=True, retry=True):
     global API_KEY
-    Log.info("Requesting: %s", url)
-    api_string = ''
-    if authenticate:
-        api_string = '&apikey=%s' % GetApiKey()
+    Log.info('Requesting: %s', url)
 
     myheaders = {'Accept': 'application/json'}
+
+    if authenticate:
+        myheaders['apikey'] = GetApiKey()
     
     try:
-        req = urllib2.Request('http://%s:%s/%s%s' % (Prefs['Hostname'], Prefs['Port'], url, api_string), headers=myheaders)
+        req = urllib2.Request('http://%s:%s/%s' % (Prefs['Hostname'], Prefs['Port'], url), headers=myheaders)
         return json.load(urllib2.urlopen(req))
     except Exception, e:
         if not retry:
@@ -84,22 +93,24 @@ def GetApiKey():
     global API_KEY
 
     if not API_KEY:
-        data = '{"user":"%s", "pass":"%s", "device":"%s"}' % (
-            Prefs['Username'], Prefs['Password'] if Prefs['Password'] != None else '', 'Shoko Series Scanner For Plex')
+        data = json.dumps({
+            'user': Prefs['Username'],
+            'pass': Prefs['Password'] if Prefs['Password'] != None else '',
+            'device': 'Shoko Series Scanner For Plex'
+        })
         resp = HttpPost('api/auth', data)['apikey']
-        Log.info( "Got API KEY: %s", resp)
+        Log.info( 'Got API KEY: %s', resp)
         API_KEY = resp
         return resp
 
     return API_KEY
-
 
 def Scan(path, files, mediaList, subdirs, language=None, root=None):
     Log.debug('path: %s', path)
     Log.debug('files: %s', files)
 
     for subdir in subdirs:
-        Log.info("[folder] " + os.path.relpath(subdir, root))
+        Log.info('[folder] ' + os.path.relpath(subdir, root))
 
     if files:
         
@@ -108,49 +119,80 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
         
         for idx, file in enumerate(files):
             try:
-                Log.info('file: %s', file)
-                # http://127.0.0.1:8111/api/ep/getbyfilename?apikey=d422dfd2-bdc3-4219-b3bb-08b85aa65579&filename=%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
+                Log.info('File: %s', file)
 
-                episode_data = HttpReq("api/ep/getbyfilename?filename=%s" % (urllib.quote(os.path.basename(file))))
-                if len(episode_data) == 0: continue
-                if (try_get(episode_data, "code", 200) == 404): continue
+                # Get file data using filename
+                # http://127.0.0.1:8111/api/v3/File/PathEndsWith/Clannad/%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
+                file = os.path.join(os.path.split(os.path.dirname(file))[-1], os.path.basename(file)) # Parent folder + file name
+                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(file)))
+                if len(file_data) == 0: continue # Skip if file data is not found
 
-                series_data = HttpReq("api/serie/fromep?id=%d&nocast=1&notag=1" % episode_data['id'])
-                showTitle = series_data['name'].encode("utf-8") #no idea why I need to do this.
-                Log.info('show title: %s', showTitle)
+                # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
+                if len(file_data) > 1:
+                    Log.info('File search has more than 1 result. HOW DID YOU DO IT?')
+                file_data = file_data[0]
+                
+                # Ignore unrecognized files
+                if 'SeriesIDs' not in file_data:
+                    Log.info('Unrecognized file. Skipping!')
+                    continue
 
-                seasonNumber = 0
-                seasonStr = try_get(episode_data, 'season', None)
-                if episode_data['eptype'] == 'Credits': seasonNumber = -1 #season -1 for OP/ED
-                elif episode_data['eptype'] == 'Trailer': seasonNumber = -2 #season -2 for Trailer
-                elif Prefs['SingleSeasonOrdering'] or seasonStr == None:
-                    if episode_data['eptype'] == 'Episode': seasonNumber = 1
-                    elif episode_data['eptype'] == 'Special': seasonNumber = 0
-                else:
-                    seasonNumber = int(seasonStr.split('x')[0])
-                    if seasonNumber <= 0 and episode_data['eptype'] == 'Episode': seasonNumber = 1
-                    elif seasonNumber > 0 and episode_data['eptype'] == 'Special': seasonNumber = 0
+                # Get series data
+                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
+                series_data = {}
+                series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
+                series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
-                if seasonNumber == 0 and Prefs['IncludeSpecials'] == False: continue
-                if seasonNumber < 0 and Prefs['IncludeOther'] == False: continue #Ignore this by choice.
+                # Get preferred/overriden title. Preferred title is the one shown in Desktop.
+                show_title = series_data['shoko']['Name'].encode('utf-8') #no idea why I need to do this.
+                Log.info('Show Title: %s', show_title)
 
-                if (try_get(series_data, "ismovie", 0) == 1 and seasonNumber >= 1): continue # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
-                Log.info('season number: %s', seasonNumber)
-                episodeNumber = int(episode_data['epnumber'])
-                Log.info('episode number: %s', episodeNumber)
+                # Get episode data
+                ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][0]['ID'] # Taking the first link, again
+                ep_data = {}
+                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
 
-                vid = Media.Episode(showTitle, seasonNumber, episodeNumber)
+                # Get season number
+                ep_type = ep_data['anidb']['Type']
+                season = 0
+                if ep_type == EpisodeType['Episode']: season = 1
+                elif ep_type == EpisodeType['Special']: season = 0
+                elif ep_type == EpisodeType['Credits']: season = -1
+                elif ep_type == EpisodeType['Trailer']: season = -2
+                if not Prefs['SingleSeasonOrdering']:
+                    ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
+                    ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before
+                    if ep_data['tvdb'] is not None:
+                        season = ep_data['tvdb']['Season']
+                        if season <= 0 and ep_type == EpisodeType['Episode']: season = 1
+                        elif season > 0 and ep_type == EpisodeType['Special']: season = 0
+
+                # Ignore these by choice.
+                if season == 0 and Prefs['IncludeSpecials'] == False: continue
+                if season < 0 and Prefs['IncludeOther'] == False: continue
+
+                # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
+                if (try_get(series_data['anidb'], 'SeriesType', -1) == 0 and season >= 1):
+                    Log.info('It\'s a movie. Skipping!')
+                    continue
+                
+                Log.info('Season: %s', season)
+                
+                episode_number = ep_data['anidb']['EpisodeNumber']
+                Log.info('Episode Number: %s', episode_number)
+
+                vid = Media.Episode(show_title, season, episode_number)
                 Log.info('vid: %s', vid)
                 vid.parts.append(file)
                 mediaList.append(vid)
             except Exception as e:
-                Log.error("Error in Scan: '%s'" % e)
+                Log.error('Error in Scan: "%s"' % e)
                 continue
 
         Stack.Scan(path, files, mediaList, subdirs)
 
     if not path: # If current folder is root folder
-        Log.info("Manual call to group folders")
+        Log.info('Manual call to group folders')
         subfolders = subdirs[:]
 
         while subfolders: # subfolder scanning queue
@@ -172,18 +214,18 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 else:
                     subdir_files.append(path_item)
 
-            Log.info("Sub-directories: %s", subdir_dirs)
-            Log.info("Files: %s", subdir_files)
+            Log.info('Sub-directories: %s', subdir_dirs)
+            Log.info('Files: %s', subdir_files)
 
             for dir in subdir_dirs:
-                Log.info("[Added for scanning] " + dir) # Add the subfolder to subfolder scanning queue)
+                Log.info('[Added for scanning] ' + dir) # Add the subfolder to subfolder scanning queue)
                 subfolders.append(dir)
 
             grouping_dir = full_path.rsplit(os.sep, full_path.count(os.sep)-1-root.count(os.sep))[0]
             if subdir_files and (len(reverse_path)>1 or subdir_dirs):
                 if grouping_dir in subdirs:
                     subdirs.remove(grouping_dir)  #Prevent group folders from being called by Plex normal call to Scan()
-                Log.info("CALLING SCAN FOR FILES IN CURRENT FOLDER")
+                Log.info('CALLING SCAN FOR FILES IN CURRENT FOLDER')
                 Scan(path, sorted(subdir_files), mediaList, [], language, root) 
                 # relative path for dir or it will group multiple series into one as before and no empty subdirs array because they will be scanned afterwards.
             
@@ -192,7 +234,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
             Log.info('=' * 100)
 
 
-def try_get(arr, idx, default=""):
+def try_get(arr, idx, default=''):
     try:
         return arr[idx]
     except:


### PR DESCRIPTION
- Changed all endpoints to API v3
- Changed quotes and variable names to match python styling conventions. Quotes are not exactly needed to be single quotes but both single and double were being used so I just changed everything to one. (flake8 was complaining so much)
- API key is now added in headers instead of the URL
- Added subdirectories support to movie scanner also.

Misc:
- Plex uses python<=2.6 (far less features than it should have)
- python2 doesn't have support for enums
- python is annoying