### PR TITLE
API v3 rewrite, various fixes and some new features

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -370,8 +370,6 @@ class ShokoCommonAgent:
                 if not Prefs['SingleSeasonOrdering'] and len(ep_data['tvdb']) != 0:
                     ep_data['tvdb'] = ep_data['tvdb'][0] # Take the first link, as explained before
                     season = ep_data['tvdb']['Season']
-                    if season <= 0 and ep_type == 'Normal': season = 1
-                    elif season > 0 and ep_type == 'Special': season = 0
 
                 Log('Season: %s', season)
                 Log('Episode: %s', ep_data['anidb']['EpisodeNumber'])

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -123,8 +123,8 @@ class ShokoCommonAgent:
                 full_title = series_data['shoko']['Name'] + ' - ' + title
 
                 # Get year from air date
-                air_date = try_get(ep_data['anidb'], 'AirDate', None)
-                year = air_date.split('-')[0] if air_date is not None else None
+                airdate = try_get(ep_data['anidb'], 'AirDate', '0001-01-01')
+                year = airdate.split('-')[0] if airdate != '0001-01-01' else None
 
                 score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
 
@@ -167,8 +167,8 @@ class ShokoCommonAgent:
                         full_title = series_data['shoko']['Name'] + ' - ' + title
 
                         # Get year from air date
-                        air_date = try_get(ep_data['anidb'], 'AirDate', None)
-                        year = air_date.split('-')[0] if air_date is not None else None
+                        airdate = try_get(ep_data['anidb'], 'AirDate', '0001-01-01')
+                        year = airdate.split('-')[0] if airdate != '0001-01-01' else None
 
                         if title == name: score = 100 # Check if full name matches (Series name + episode name)
                         elif result['Name'] == name: score = 90 # Check if series name matches
@@ -189,8 +189,8 @@ class ShokoCommonAgent:
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id)
 
                 # Get year from air date
-                air_date = try_get(series_data['anidb'], 'AirDate', None)
-                year = air_date.split('-')[0] if air_date is not None else None
+                airdate = try_get(series_data['anidb'], 'AirDate', '0001-01-01')
+                year = airdate.split('-')[0] if airdate != '0001-01-01' else None
 
                 score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
 
@@ -395,9 +395,9 @@ class ShokoCommonAgent:
                     Log('Description: %s' % episode_obj.summary)
 
                 # Get air date
-                air_date = try_get(ep_data['anidb'], 'AirDate', None)
-                if air_date is not None:
-                    episode_obj.originally_available_at = datetime.strptime(air_date, '%Y-%m-%d').date()
+                airdate = try_get(ep_data['anidb'], 'AirDate', '0001-01-01')
+                if airdate != '0001-01-01':
+                    episode_obj.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
 
                 if Prefs['customThumbs']:
                    self.metadata_add(episode_obj.thumbs, [try_get(try_get(ep_data['tvdb'], 0, {}), 'Thumbnail', {})])

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -394,9 +394,19 @@ class ShokoCommonAgent:
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
 
-                # TvDB episode title fallback
+                # Replace Ambiguous Titles with Series Title
                 SingleEntryTitles = ['Complete Movie', 'Music Video', 'OAD', 'OVA', 'Short Movie', 'TV Special', 'Web'] # AniDB titles used for single entries which are ambiguous
-                if (title in SingleEntryTitles or title.startswith('Episode ')) and try_get(ep_data['tvdb'], 'Title') != '':
+                if title in SingleEntryTitles:
+                    # Make a dict of language -> title for all series titles in anidb data
+                    series_titles = {}
+                    for item in series_data['anidb']['Titles']:
+                        series_titles[item['Language']] = item['Name']
+                                   
+                    title = series_titles[lang.lower()] # Get series title according to the preference above
+                    if title is None: title = ep_titles['en'] # If not found, fallback to EN series title
+
+                # TvDB episode title fallback
+                if title.startswith('Episode ') and try_get(ep_data['tvdb'], 'Title') != '':
                     title = try_get(ep_data['tvdb'], 'Title')
 
                 episode_obj.title = title
@@ -435,7 +445,7 @@ class ShokoCommonAgent:
                     director = episode_obj.directors.new()
                     director.name = directors['Staff']['Name']
 
-            # Set custom negative season names
+            # Set custom negative season names (To be enabled if Plex fixes blocking issue)
             # for season_num in metadata.seasons:
             #    season_title = None
             #    if season_num == '-1': season_title = 'Themes'

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -322,7 +322,7 @@ class ShokoCommonAgent:
             Log('Assumed tv rating to be: %s' % metadata.content_rating)
 
         # Get cast
-        cast = HttpReq('api/v3/Series/%s/Cast' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast
+        cast = HttpReq('api/v3/Series/%s/Cast?roleType=Seiyuu' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Seiyuu
         metadata.roles.clear()
         Log('Cast')
         for role in cast:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -98,7 +98,7 @@ class ShokoCommonAgent:
                     return
 
                 # Get series data
-                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
+                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
                 series_data = {}
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -403,7 +403,8 @@ class ShokoCommonAgent:
                     # Make a dict of language -> title for all series titles in anidb data
                     series_titles = {}
                     for item in series_data['anidb']['Titles']:
-                        series_titles[item['Language']] = item['Name']
+                        if item['Type'] != 'Short': # Exclude all short titles
+                            series_titles.setdefault(item['Language'], item['Name']) # Use setdefault() to use the first title for each language
                     
                     # Get series title according to the preference
                     singleTitle = title

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -131,7 +131,7 @@ class ShokoCommonAgent:
                 Log('Searching movie %s' % name)
 
                 # Search for series using the name
-                prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
+                prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
 
                 for result in prelimresults:
                     # Get episode list using series ID
@@ -174,7 +174,7 @@ class ShokoCommonAgent:
 
         else:
             # Search for series using the name
-            prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
+            prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
 
             for result in prelimresults:
                 # Get series data

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -333,6 +333,12 @@ class ShokoCommonAgent:
             image = role['Staff']['Image']
             meta_role.photo = 'http://{host}:{port}/api/v3/Image/{source}/{type}/{id}'.format(host=Prefs['Hostname'], port=Prefs['Port'], source=image['Source'], type=image['Type'], id=image['ID'])
 
+        # Get studio
+        studio = HttpReq('api/v3/Series/%s/Cast?roleType=Studio' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Studio
+        studio = try_get(studio, 0, False)
+        if studio:
+            Log('Studio: %s', studio['Staff']['Name'])
+            metadata.studio = studio['Staff']['Name']
 
         if not movie:
             # Get episode list using series ID

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -397,8 +397,8 @@ class ShokoCommonAgent:
                 if air_date is not None:
                     episode_obj.originally_available_at = datetime.strptime(air_date, '%Y-%m-%d').date()
 
-                if Prefs['customThumbs'] and 'Thumbnail' in ep_data['tvdb']:
-                   self.metadata_add(episode_obj.thumbs, [ep_data['tvdb']['Thumbnail']])
+                if Prefs['customThumbs']:
+                   self.metadata_add(episode_obj.thumbs, [try_get(try_get(ep_data['tvdb'], 0, {}), 'Thumbnail', {})])
 
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -436,15 +436,15 @@ class ShokoCommonAgent:
                     director.name = directors['Staff']['Name']
 
             # Set custom negative season names
-            for season_num in metadata.seasons:
-                season_title = None
-                if season_num == '-1': season_title = 'Themes'
-                elif season_num == '-2': season_title = 'Trailers'
-                elif season_num == '-3': season_title = 'Parodies'
-                elif season_num == '-4': season_title = 'Other'
-                if int(season_num) < 0 and season_title is not None:
-                    Log('Renaming season: %s to %s' % (season_num, season_title))
-                    metadata.seasons[season_num].title = season_title
+            # for season_num in metadata.seasons:
+            #    season_title = None
+            #    if season_num == '-1': season_title = 'Themes'
+            #    elif season_num == '-2': season_title = 'Trailers'
+            #    elif season_num == '-3': season_title = 'Parodies'
+            #    elif season_num == '-4': season_title = 'Other'
+            #    if int(season_num) < 0 and season_title is not None:
+            #        Log('Renaming season: %s to %s' % (season_num, season_title))
+            #        metadata.seasons[season_num].title = season_title
 
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -350,7 +350,7 @@ class ShokoCommonAgent:
 
         if not movie:
             # Get episode list using series ID
-            episodes = HttpReq('api/v3/Series/%s/Episode' % aid) # http://127.0.0.1:8111/api/v3/Series/212/Episode
+            episodes = HttpReq('api/v3/Series/%s/Episode?pageSize=0' % aid) # http://127.0.0.1:8111/api/v3/Series/212/Episode?pageSize=0
 
             for episode in episodes['List']:
                 # Get episode data

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -402,7 +402,7 @@ class ShokoCommonAgent:
 
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:
-                for tid in links["tvdb"]:
+                for tid in try_get(series_data['shoko']['IDs'],'TvDB', []):
                     if THEME_URL % tid not in metadata.themes:
                         try:
                             metadata.themes[THEME_URL % tid] = Proxy.Media(HTTP.Request(THEME_URL % tid))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -337,6 +337,9 @@ class ShokoCommonAgent:
         # Get studio
         studio = HttpReq('api/v3/Series/%s/Cast?roleType=Studio' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Studio
         studio = try_get(studio, 0, False)
+        if not studio:
+            studio = HttpReq('api/v3/Series/%s/Cast?roleDetails=Work' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleDetails=Work
+            studio = try_get(studio, 0, False)
         if studio:
             Log('Studio: %s', studio['Staff']['Name'])
             metadata.studio = studio['Staff']['Name']
@@ -401,6 +404,22 @@ class ShokoCommonAgent:
 
                 if Prefs['customThumbs']:
                    self.metadata_add(episode_obj.thumbs, [try_get(try_get(ep_data['tvdb'], 0, {}), 'Thumbnail', {})])
+
+                # Get writers (as original work)
+                writers = HttpReq('api/v3/Series/%s/Cast?roleType=SourceWork' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=SourceWork
+                writers = try_get(writers, 0, False)
+                if writers:
+                    Log('Writers: %s', writers['Staff']['Name'])
+                    writer = episode_obj.writers.new()
+                    writer.name = writers['Staff']['Name']
+
+                # Get directors
+                directors = HttpReq('api/v3/Series/%s/Cast?roleType=Director' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Director
+                directors = try_get(directors, 0, False)
+                if directors:
+                    Log('Directors: %s', directors['Staff']['Name'])
+                    director = episode_obj.directors.new()
+                    director.name = directors['Staff']['Name']
 
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -45,8 +45,6 @@ def GetApiKey():
 
     return API_KEY
 
-auth_headers = {'apikey': GetApiKey()}
-
 def HttpPost(url, postdata):
     myheaders = {'Content-Type': 'application/json'}
     return JSON.ObjectFromString(
@@ -54,12 +52,11 @@ def HttpPost(url, postdata):
                      data=postdata).content)
 
 
-def HttpReq(url, authenticate=True, retry=True):
+def HttpReq(url, retry=True):
     global API_KEY
     Log("Requesting: %s" % url)
 
-    if authenticate:
-        myheaders = auth_headers
+    myheaders = {'apikey': GetApiKey()}
 
     try:
         return JSON.ObjectFromString(
@@ -69,7 +66,7 @@ def HttpReq(url, authenticate=True, retry=True):
             raise e
 
         API_KEY = ''
-        return HttpReq(url, authenticate, False)
+        return HttpReq(url, False)
         
 
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -126,7 +126,7 @@ class ShokoCommonAgent:
                 airdate = try_get(ep_data['anidb'], 'AirDate', None)
                 year = airdate.split('-')[0] if airdate is not None else None
 
-                score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
+                score = 100 # TODO: Improve this to respect synonyms./
 
                 meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
                 results.Append(meta)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -415,7 +415,7 @@ class ShokoCommonAgent:
                 meta[url] = Proxy.Media(HTTP.Request(url).content, idx)
                 valid.append(url)
             except Exception as e:
-                Log("[metadata_add] :: Invalid URL given (%s), skipping" % url)
+                Log("[metadata_add] :: Invalid URL given (%s), skipping" % try_get(art, 'url', ''))
                 Log(e)
 
         meta.validate_keys(valid)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -338,7 +338,7 @@ class ShokoCommonAgent:
         studio = HttpReq('api/v3/Series/%s/Cast?roleType=Studio' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Studio
         studio = try_get(studio, 0, False)
         if not studio:
-            studio = HttpReq('api/v3/Series/%s/Cast?roleDetails=Work' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleDetails=Work
+            studio = HttpReq('api/v3/Series/%s/Cast?roleType=Staff&roleDetails=Work' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Staff&roleDetails=Work
             studio = try_get(studio, 0, False)
         if studio:
             Log('Studio: %s', studio['Staff']['Name'])

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -117,7 +117,7 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = ep_titles[lang.lower()]
+                    if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                 full_title = series_data['shoko']['Name'] + ' - ' + title
@@ -161,7 +161,7 @@ class ShokoCommonAgent:
                         title = None
                         for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                             lang = lang.strip()
-                            title = ep_titles[lang.lower()]
+                            if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
                             if title is not None: break
                         if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                         full_title = series_data['shoko']['Name'] + ' - ' + title
@@ -237,7 +237,7 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = ep_titles[lang.lower()]
+                    if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                 movie_name = series_data['shoko']['Name'] + ' - ' + title
@@ -390,7 +390,7 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = ep_titles[lang.lower()]
+                    if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
 
@@ -401,9 +401,17 @@ class ShokoCommonAgent:
                     series_titles = {}
                     for item in series_data['anidb']['Titles']:
                         series_titles[item['Language']] = item['Name']
-                                   
-                    title = series_titles[lang.lower()] # Get series title according to the preference above
-                    if title is None: title = series_titles['en'] # If not found, fallback to EN series title
+                    
+                    # Get series title according to the preference
+                    singleTitle = title
+                    for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
+                        lang = lang.strip()                                   
+                        if lang.lower() in series_titles: title = series_titles[lang.lower()]
+                        if title is not singleTitle: break
+                    if title is singleTitle:
+                        if 'en' in series_titles: title = series_titles['en'] # If not found, fallback to EN series title
+                    else: # Fallback to TvDB title as a last resort
+                        if try_get(ep_data['tvdb'], 'Title') != '': title = try_get(ep_data['tvdb'], 'Title')
 
                 # TvDB episode title fallback
                 if title.startswith('Episode ') and try_get(ep_data['tvdb'], 'Title') != '':

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -131,7 +131,7 @@ class ShokoCommonAgent:
                 Log('Searching movie %s' % name)
 
                 # Search for series using the name
-                prelimresults = HttpReq('api/v3/Series/Search/%s' % urllib.quote(name.encode('utf8'))) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad
+                prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
 
                 for result in prelimresults:
                     # Get episode list using series ID
@@ -174,7 +174,7 @@ class ShokoCommonAgent:
 
         else:
             # Search for series using the name
-            prelimresults = HttpReq('api/v3/Series/Search/%s' % urllib.quote(name.encode('utf8'))) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad
+            prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
 
             for result in prelimresults:
                 # Get series data

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -88,12 +88,13 @@ class ShokoCommonAgent:
         if movie:
             if media.filename:
                 filename = urllib.unquote(media.filename)
+                filename = os.path.join(os.path.split(os.path.dirname(filename))[-1], os.path.basename(filename)) # Parent folder + file name
 
                 Log('Searching movie %s - %s' % (name, filename))
 
                 # Get file data using filename
                 # http://127.0.0.1:8111/api/v3/File/PathEndsWith/%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
-                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % filename)
+                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(filename)))
 
                 # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
                 if len(file_data) > 1:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -121,7 +121,7 @@ class ShokoCommonAgent:
                 air_date = try_get(ep_data['anidb'], 'AirDate', None)
                 year = air_date.split('-')[0] if air_date is not None else None
 
-                score = 100 if series_data['shoko']['Name'] == name else 85  # TODO: Improve this to respect synonyms./
+                score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
 
                 meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
                 results.Append(meta)
@@ -187,7 +187,7 @@ class ShokoCommonAgent:
                 air_date = try_get(series_data['anidb'], 'AirDate', None)
                 year = air_date.split('-')[0] if air_date is not None else None
 
-                score = 100 if series_data['shoko']['Name'] == name else 85  # TODO: Improve this to respect synonyms./
+                score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
 
                 meta = MetadataSearchResult(str(series_id), series_data['shoko']['Name'], year, score, lang)
                 results.Append(meta)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -296,28 +296,29 @@ class ShokoCommonAgent:
         ### VERY rough approximation to: https://www.healthychildren.org/English/family-life/Media/Pages/TV-Ratings-A-Guide-for-Parents.aspx
 
         if Prefs["Ratings"]:
-            if 'kodomo' in tags:
+            tags_lower = [tag.lower() for tag in tags] # Account for inconsistent capitalization of tags
+            if 'kodomo' in tags_lower:
                 metadata.content_rating = 'TV-Y'
 
-            if 'Mina' in tags:
+            if 'mina' in tags_lower:
                 metadata.content_rating = 'TV-G'
 
-            if 'Shoujo' in tags:
+            if 'shoujo' in tags_lower:
                 metadata.content_rating = 'TV-14'
 
-            if 'Shounen' in tags:
+            if 'shounen' in tags_lower:
                 metadata.content_rating = 'TV-14'
 
-            if 'Josei' in tags:
+            if 'josei' in tags_lower:
                 metadata.content_rating = 'TV-14'
 
-            if 'Seinen' in tags:
+            if 'seinen' in tags_lower:
                 metadata.content_rating = 'TV-MA'
 
-            if 'borderline porn' in tags:
+            if 'borderline porn' in tags_lower:
                 metadata.content_rating = 'TV-MA'
 
-            if '18 restricted' in tags:
+            if '18 restricted' in tags_lower:
                 metadata.content_rating = 'X'
 
             Log('Assumed tv rating to be: %s' % metadata.content_rating)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -393,6 +393,12 @@ class ShokoCommonAgent:
                     title = ep_titles[lang.lower()]
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
+
+                # TvDB episode title fallback
+                SingleEntryTitles = ['Complete Movie', 'Music Video', 'OAD', 'OVA', 'Short Movie', 'TV Special', 'Web'] # AniDB titles used for single entries which are ambiguous
+                if (title in SingleEntryTitles or title.startswith('Episode ')) and try_get(ep_data['tvdb'], 'Title') != '':
+                    title = try_get(ep_data['tvdb'], 'Title')
+
                 episode_obj.title = title
 
                 Log('Episode Title: %s', episode_obj.title)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -104,32 +104,34 @@ class ShokoCommonAgent:
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
                 # Get episode data
-                ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][0]['ID'] # Taking the first
-                ep_data = {}
-                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+                ep_multi = len(file_data['SeriesIDs'][0]['EpisodeIDs']) # Account for multi episode files
+                for ep in range(ep_multi):
+                    ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][ep]['ID']
+                    ep_data = {}
+                    ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
 
-                # Make a dict of language -> title for all titles in anidb data
-                ep_titles = {}
-                for item in ep_data['anidb']['Titles']:
-                    ep_titles[item['Language']] = item['Name']
+                    # Make a dict of language -> title for all titles in anidb data
+                    ep_titles = {}
+                    for item in ep_data['anidb']['Titles']:
+                        ep_titles[item['Language']] = item['Name']
 
-                # Get episode title according to the preference
-                title = None
-                for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
-                    lang = lang.strip()
-                    title = try_get(ep_titles, lang.lower(), None)
-                    if title is not None: break
-                if title is None: title = ep_titles['en'] # If not found, fallback to EN title
-                full_title = series_data['shoko']['Name'] + ' - ' + title
+                    # Get episode title according to the preference
+                    title = None
+                    for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
+                        lang = lang.strip()
+                        title = try_get(ep_titles, lang.lower(), None)
+                        if title is not None: break
+                    if title is None: title = ep_titles['en'] # If not found, fallback to EN title
+                    full_title = series_data['shoko']['Name'] + ' - ' + title
 
-                # Get year from air date
-                airdate = try_get(ep_data['anidb'], 'AirDate', None)
-                year = airdate.split('-')[0] if airdate is not None else None
+                    # Get year from air date
+                    airdate = try_get(ep_data['anidb'], 'AirDate', None)
+                    year = airdate.split('-')[0] if airdate is not None else None
 
-                score = 100 # TODO: Improve this to respect synonyms./
+                    score = 100 # TODO: Improve this to respect synonyms./
 
-                meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
-                results.Append(meta)
+                    meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
+                    results.Append(meta)
 
             else: # For manual searches
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -296,7 +296,7 @@ class ShokoCommonAgent:
         ### VERY rough approximation to: https://www.healthychildren.org/English/family-life/Media/Pages/TV-Ratings-A-Guide-for-Parents.aspx
 
         if Prefs["Ratings"]:
-            if 'Kodomo' in tags:
+            if 'kodomo' in tags:
                 metadata.content_rating = 'TV-Y'
 
             if 'Mina' in tags:
@@ -314,11 +314,11 @@ class ShokoCommonAgent:
             if 'Seinen' in tags:
                 metadata.content_rating = 'TV-MA'
 
-            if 'Mature' in tags:
+            if 'borderline porn' in tags:
                 metadata.content_rating = 'TV-MA'
 
-            if '18 Restricted' in tags:
-                metadata.content_rating = 'TV-R'
+            if '18 restricted' in tags:
+                metadata.content_rating = 'X'
 
             Log('Assumed tv rating to be: %s' % metadata.content_rating)
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -255,6 +255,7 @@ class ShokoCommonAgent:
             for lang in Prefs['SeriesAltTitleLanguagePreference'].split(','):
                 lang = lang.strip()
                 alt_title = try_get(series_titles, lang.lower(), None)
+                if alt_title == movie_name: continue # Skip if main title is same as alt title
                 if alt_title is not None: break
 
             if alt_title is not None:
@@ -329,6 +330,7 @@ class ShokoCommonAgent:
             for lang in Prefs['SeriesAltTitleLanguagePreference'].split(','):
                 lang = lang.strip()
                 alt_title = try_get(series_titles, lang.lower(), None)
+                if alt_title == title: continue # Skip if main title is same as alt title
                 if alt_title is not None: break
 
             metadata.title = title

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -426,6 +426,17 @@ class ShokoCommonAgent:
                     director = episode_obj.directors.new()
                     director.name = directors['Staff']['Name']
 
+            # Set custom negative season names
+            for season_num in metadata.seasons:
+                season_title = None
+                if season_num == '-1': season_title = 'Themes'
+                elif season_num == '-2': season_title = 'Trailers'
+                elif season_num == '-3': season_title = 'Parodies'
+                elif season_num == '-4': season_title = 'Other'
+                if int(season_num) < 0 and season_title is not None:
+                    Log('Renaming season: %s to %s' % (season_num, season_title))
+                    metadata.seasons[season_num].title = season_title
+
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:
                 for tid in try_get(series_data['shoko']['IDs'],'TvDB', []):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -226,6 +226,7 @@ class ShokoCommonAgent:
             # Make a dict of language -> title for all series titles in anidb data + add preferred title in Shoko
             series_titles = {}
             for item in series_data['AniDB']['Titles']:
+                if item['Language'] == 'x-jat' and item['Type'] != 'Main': continue # Skip x-jat synonym titles and always take the main title
                 series_titles[item['Language']] = item['Name']
             series_titles['shoko'] = series_data['Name']
 
@@ -282,6 +283,7 @@ class ShokoCommonAgent:
             # Make a dict of language -> title for all series titles in anidb data + add preferred title in Shoko
             series_titles = {}
             for item in series_data['AniDB']['Titles']:
+                if item['Language'] == 'x-jat' and item['Type'] != 'Main': continue # Skip x-jat synonym titles and always take the main title
                 if item['Type'] != 'Short': # Exclude all short titles
                     series_titles[item['Language']] = item['Name']
             series_titles['shoko'] = series_data['Name']
@@ -295,7 +297,16 @@ class ShokoCommonAgent:
             if title is None: title = series_titles['shoko'] # If not found, fallback to preferred title in Shoko
 
             metadata.title = title
-            metadata.title_sort = title
+            original_title = try_get(series_titles, 'x-jat', None)
+
+            if original_title is not None:
+                # Append the original title to the sort title to make it searchable
+                metadata.title_sort = title + ' [' + original_title + ']'
+                # Set metadata.original_title to main x-jat title (if Plex fixes blocking issue)
+                # metadata.original_title = try_get(series_titles, 'x-jat', None)
+            else:
+                metadata.title_sort = title
+
             Log('Series Title: %s' % title)
 
             # Get air date

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -333,7 +333,8 @@ class ShokoCommonAgent:
             meta_role.role = role['Character']['Name']
             Log('%s - %s' % (meta_role.role, meta_role.name))
             image = role['Staff']['Image']
-            meta_role.photo = 'http://{host}:{port}/api/v3/Image/{source}/{type}/{id}'.format(host=Prefs['Hostname'], port=Prefs['Port'], source=image['Source'], type=image['Type'], id=image['ID'])
+            if image:
+                meta_role.photo = 'http://{host}:{port}/api/v3/Image/{source}/{type}/{id}'.format(host=Prefs['Hostname'], port=Prefs['Port'], source=image['Source'], type=image['Type'], id=image['ID'])
 
         # Get studio
         studio = HttpReq('api/v3/Series/%s/Cast?roleType=Studio' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=Studio

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -103,38 +103,35 @@ class ShokoCommonAgent:
                     return
 
                 series_id = series_ids['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
-                series_data = {}
-                series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
-                series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
+                series_data = HttpReq('api/v3/Series/%s?includeDataFrom=AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24?includeDataFrom=AniDB
 
                 # Get episode data
-                ep_multi = len(file_data['SeriesIDs'][0]['EpisodeIDs']) # Account for multi episode files
-                for ep in range(ep_multi):
-                    ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][ep]['ID']
-                    ep_data = {}
-                    ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+                episode_multi = len(file_data['SeriesIDs'][0]['EpisodeIDs']) # Account for multi episode files
+                for episode in range(episode_multi):
+                    episode_id = file_data['SeriesIDs'][0]['EpisodeIDs'][episode]['ID']
+                    anidb_episode_data = HttpReq('api/v3/Episode/%s/AniDB' % episode_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
 
                     # Make a dict of language -> title for all titles in anidb data
-                    ep_titles = {}
-                    for item in ep_data['anidb']['Titles']:
-                        ep_titles[item['Language']] = item['Name']
+                    episode_titles = {}
+                    for item in anidb_episode_data['Titles']:
+                        episode_titles[item['Language']] = item['Name']
 
                     # Get episode title according to the preference
                     title = None
                     for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                         lang = lang.strip()
-                        title = try_get(ep_titles, lang.lower(), None)
+                        title = try_get(episode_titles, lang.lower(), None)
                         if title is not None: break
-                    if title is None: title = ep_titles['en'] # If not found, fallback to EN title
-                    full_title = series_data['shoko']['Name'] + ' - ' + title
+                    if title is None: title = episode_titles['en'] # If not found, fallback to EN title
+                    full_title = series_data['Name'] + ' - ' + title
 
                     # Get year from air date
-                    airdate = try_get(ep_data['anidb'], 'AirDate', None)
+                    airdate = try_get(anidb_episode_data, 'AirDate', None)
                     year = airdate.split('-')[0] if airdate is not None else None
 
                     score = 100 # TODO: Improve this to respect synonyms./
 
-                    meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
+                    meta = MetadataSearchResult(str(episode_id), full_title, year, score, lang)
                     results.Append(meta)
 
             else: # For manual searches
@@ -150,56 +147,53 @@ class ShokoCommonAgent:
 
                     for episode in episodes:
                         # Get episode data
-                        ep_id = episode['IDs']['ID']
-                        ep_data = {}
-                        ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+                        episode_id = episode['IDs']['ID']
+                        anidb_episode_data = HttpReq('api/v3/Episode/%s/AniDB' % episode_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
 
                         # Get series data
-                        series_data = {}
-                        series_data['shoko'] = HttpReq('api/v3/Episode/%s/Series' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/Series
+                        series_data = HttpReq('api/v3/Episode/%s/Series' % episode_id) # http://127.0.0.1:8111/api/v3/Episode/212/Series
 
                         # Make a dict of language -> title for all titles in anidb data
-                        ep_titles = {}
-                        for item in ep_data['anidb']['Titles']:
-                            ep_titles[item['Language']] = item['Name']
+                        episode_titles = {}
+                        for item in anidb_episode_data['Titles']:
+                            episode_titles[item['Language']] = item['Name']
 
                         # Get episode title according to the preference
                         title = None
                         for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                             lang = lang.strip()
-                            title = try_get(ep_titles, lang.lower(), None)
+                            title = try_get(episode_titles, lang.lower(), None)
                             if title is not None: break
-                        if title is None: title = ep_titles['en'] # If not found, fallback to EN title
-                        full_title = series_data['shoko']['Name'] + ' - ' + title
+                        if title is None: title = episode_titles['en'] # If not found, fallback to EN title
+                        full_title = series_data['Name'] + ' - ' + title
 
                         # Get year from air date
-                        airdate = try_get(ep_data['anidb'], 'AirDate', None)
+                        airdate = try_get(anidb_episode_data, 'AirDate', None)
                         year = airdate.split('-')[0] if airdate is not None else None
 
                         if title == name: score = 100 # Check if full name matches (Series name + episode name)
                         elif result['Name'] == name: score = 90 # Check if series name matches
                         else: score = 80
 
-                        meta = MetadataSearchResult(str(ep_id), full_title, year, score, lang)
+                        meta = MetadataSearchResult(str(episode_id), full_title, year, score, lang)
                         results.Append(meta)
 
         else:
             # Search for series using the name
             prelimresults = HttpReq('api/v3/Series/Search?query=%s&fuzzy=%s&limit=10' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search?query=Clannad&fuzzy=true&limit=10
 
-            for index, result in enumerate(prelimresults):
+            for index, series_data in enumerate(prelimresults):
                 # Get series data
-                series_id = result['IDs']['ID']
-                # Just to make it uniform across every place it's used
-                series_data = {'shoko': result, 'anidb': HttpReq('api/v3/Series/%s/AniDB' % series_id)}
+                series_id = series_data['IDs']['ID']
+                anidb_series_data = HttpReq('api/v3/Series/%s/AniDB' % series_id)
 
                 # Get year from air date
-                airdate = try_get(series_data['anidb'], 'AirDate', None)
+                airdate = try_get(anidb_series_data, 'AirDate', None)
                 year = airdate.split('-')[0] if airdate is not None else None
 
-                score = 100 if series_data['shoko']['Name'] == name else 100 - index - int(result['Distance'] * 100)
+                score = 100 if series_data['Name'] == name else 100 - index - int(series_data['Distance'] * 100)
 
-                meta = MetadataSearchResult(str(series_id), series_data['shoko']['Name'], year, score, lang)
+                meta = MetadataSearchResult(str(series_id), series_data['Name'], year, score, lang)
                 results.Append(meta)
 
                 # results.Sort('score', descending=True)
@@ -217,69 +211,64 @@ class ShokoCommonAgent:
 
         if movie:
             # Get series data
-            series_data = {}
-            series_data['shoko'] = HttpReq('api/v3/Episode/%s/Series' % aid) # http://127.0.0.1:8111/api/v3/Series/24
-            series_id = try_get(series_data['shoko'], 'IDs')
+            series_data = HttpReq('api/v3/Episode/%s/Series?includeDataFrom=AniDB' % aid) # http://127.0.0.1:8111/api/v3/Episode/212/Series?includeDataFrom=AniDB
+            series_id = try_get(series_data, 'IDs')
             series_id = try_get(series_id, 'ID')
-            series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
             # Get episode data
-            ep_data = {}
-            ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % (aid)) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+            anidb_episode_data = HttpReq('api/v3/Episode/%s/AniDB' % (aid)) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
 
             aid = series_id # Change aid to series ID
 
             # Make a dict of language -> title for all titles in anidb data
-            ep_titles = {}
-            for item in ep_data['anidb']['Titles']:
-                ep_titles[item['Language']] = item['Name']
+            episode_titles = {}
+            for item in anidb_episode_data['Titles']:
+                episode_titles[item['Language']] = item['Name']
 
-            title = try_get(ep_titles, 'en', None)
+            title = try_get(episode_titles, 'en', None)
             if title in ['Complete Movie', 'Web']:
-                movie_name = series_data['anidb']['Name']
-                movie_sort_name = series_data['anidb']['Name']
+                movie_name = series_data['AniDB']['Name']
+                movie_sort_name = series_data['AniDB']['Name']
             else:
                 # Get episode title according to the preference
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = try_get(ep_titles, lang.lower(), None)
+                    title = try_get(episode_titles, lang.lower(), None)
                     if title is not None: break
-                if title is None: title = ep_titles['en'] # If not found, fallback to EN title
-                movie_name = series_data['shoko']['Name'] + ' - ' + title
-                movie_sort_name = series_data['shoko']['Name'] + ' - ' + str(ep_data['anidb']['EpisodeNumber']).zfill(3)
+                if title is None: title = episode_titles['en'] # If not found, fallback to EN title
+                movie_name = series_data['Name'] + ' - ' + title
+                movie_sort_name = series_data['Name'] + ' - ' + str(anidb_episode_data['EpisodeNumber']).zfill(3)
 
             Log('Movie Title: %s' % movie_name)
 
-            metadata.summary = summary_sanitizer(try_get(series_data['anidb'], 'Description'))
+            metadata.summary = summary_sanitizer(try_get(series_data['AniDB'], 'Description'))
             metadata.title = movie_name
             metadata.title_sort = movie_sort_name
-            metadata.rating = float(ep_data['anidb']['Rating']['Value']/100)
+            metadata.rating = float(anidb_episode_data['Rating']['Value']/100)
             
             # Get year from air date
-            airdate = try_get(ep_data['anidb'], 'AirDate', None)
+            airdate = try_get(anidb_episode_data, 'AirDate', None)
             if airdate is not None:
                 metadata.year = int(airdate.split('-')[0])
                 metadata.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
 
             collections = []
-            if series_data['shoko']['Size'] > 1:
-                collections.append(series_data['shoko']['Name'])
+            if series_data['Size'] > 1:
+                collections.append(series_data['Name'])
 
         else:
             # Get series data
-            series_data = {}
-            series_data['shoko'] = HttpReq('api/v3/Series/%s' % aid) # http://127.0.0.1:8111/api/v3/Series/24
-            series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % aid) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
+            series_data = HttpReq('api/v3/Series/%s?includeDataFrom=AniDB' % aid) # http://127.0.0.1:8111/api/v3/Series/24?includeDataFrom=AniDB
 
-            Log('Series Title: %s' % series_data['shoko']['Name'])
+            Log('Series Title: %s' % series_data['Name'])
 
-            metadata.summary = summary_sanitizer(try_get(series_data['anidb'], 'Description'))
-            metadata.title = series_data['shoko']['Name']
-            metadata.rating = float(series_data['anidb']['Rating']['Value']/100)
+            metadata.summary = summary_sanitizer(try_get(series_data['AniDB'], 'Description'))
+            metadata.title = series_data['Name']
+            metadata.rating = float(series_data['AniDB']['Rating']['Value']/100)
 
             # Get air date
-            airdate = try_get(series_data['anidb'], 'AirDate', None)
+            airdate = try_get(series_data['AniDB'], 'AirDate', None)
             if airdate is not None:
                 metadata.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
 
@@ -289,7 +278,7 @@ class ShokoCommonAgent:
         metadata.genres = tags
 
         # Get images
-        images = try_get(series_data['shoko'], 'Images', {})
+        images = try_get(series_data 'Images', {})
         self.metadata_add(metadata.banners, try_get(images, 'Banners', []))
         self.metadata_add(metadata.posters, try_get(images, 'Posters', []))
         self.metadata_add(metadata.art, try_get(images, 'Fanarts', []))
@@ -358,30 +347,28 @@ class ShokoCommonAgent:
 
             for episode in episodes['List']:
                 # Get episode data
-                ep_id = episode['IDs']['ID']
-                ep_data = {}
-                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
-                ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
+                episode_id = episode['IDs']['ID']
+                episode_data = HttpReq('api/v3/Episode/%s?includeDataFrom=AniDB,TvDB' % episode_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB?includeDataFrom=AniDB,TvDB
 
                 # Get episode type
-                ep_type = ep_data['anidb']['Type']
+                episode_type = episode_data['AniDB']['Type']
 
                 # Get season number
                 season = 0
                 episode_number = None
-                if ep_type == 'Normal': season = 1
-                elif ep_type == 'Special': season = 0
-                elif ep_type == 'ThemeSong': season = -1
-                elif ep_type == 'Trailer': season = -2
-                elif ep_type == 'Parody': season = -3
-                elif ep_type == 'Unknown': season = -4
-                if not Prefs['SingleSeasonOrdering'] and len(ep_data['tvdb']) != 0:
-                    ep_data['tvdb'] = ep_data['tvdb'][0] # Take the first link, as explained before
-                    season = ep_data['tvdb']['Season']
-                    episode_number = ep_data['tvdb']['Number']
+                if episode_type == 'Normal': season = 1
+                elif episode_type == 'Special': season = 0
+                elif episode_type == 'ThemeSong': season = -1
+                elif episode_type == 'Trailer': season = -2
+                elif episode_type == 'Parody': season = -3
+                elif episode_type == 'Unknown': season = -4
+                if not Prefs['SingleSeasonOrdering'] and len(episode_data['TvDB']) != 0:
+                    episode_data['TvDB'] = episode_data['TvDB'][0] # Take the first link, as explained before
+                    season = episode_data['TvDB']['Season']
+                    episode_number = episode_data['TvDB']['Number']
 
                 if episode_number is None:
-                    episode_number = ep_data['anidb']['EpisodeNumber']
+                    episode_number = episode_data['AniDB']['EpisodeNumber']
 
                 Log('Season: %s', season)
                 Log('Episode: %s', episode_number)
@@ -389,24 +376,24 @@ class ShokoCommonAgent:
                 episode_obj = metadata.seasons[season].episodes[episode_number]
 
                 # Make a dict of language -> title for all titles in anidb data
-                ep_titles = {}
-                for item in ep_data['anidb']['Titles']:
-                    ep_titles[item['Language']] = item['Name']
+                episode_titles = {}
+                for item in episode_data['AniDB']['Titles']:
+                    episode_titles[item['Language']] = item['Name']
 
                 # Get episode title according to the preference
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = try_get(ep_titles, lang.lower(), None)
+                    title = try_get(episode_titles, lang.lower(), None)
                     if title is not None: break
-                if title is None: title = ep_titles['en'] # If not found, fallback to EN title
+                if title is None: title = episode_titles['en'] # If not found, fallback to EN title
 
                 # Replace Ambiguous Titles with Series Title
                 SingleEntryTitles = ['Complete Movie', 'Music Video', 'OAD', 'OVA', 'Short Movie', 'TV Special', 'Web'] # AniDB titles used for single entries which are ambiguous
                 if title in SingleEntryTitles:
                     # Make a dict of language -> title for all series titles in anidb data
                     series_titles = {}
-                    for item in series_data['anidb']['Titles']:
+                    for item in series_data['AniDB']['Titles']:
                         if item['Type'] != 'Short': # Exclude all short titles
                             series_titles.setdefault(item['Language'], item['Name']) # Use setdefault() to use the first title for each language
                     
@@ -419,31 +406,31 @@ class ShokoCommonAgent:
                     if title is singleTitle: # If not found, fallback to EN series title
                         title = try_get(series_titles, 'en', title)
                     if title is singleTitle: # Fallback to TvDB title as a last resort
-                        if try_get(ep_data['tvdb'], 'Title') != '': title = try_get(ep_data['tvdb'], 'Title')
+                        if try_get(episode_data['TvDB'], 'Title') != '': title = try_get(episode_data['TvDB'], 'Title')
 
                 # TvDB episode title fallback
-                if title.startswith('Episode ') and try_get(ep_data['tvdb'], 'Title') != '':
-                    title = try_get(ep_data['tvdb'], 'Title')
+                if title.startswith('Episode ') and try_get(episode_data['TvDB'], 'Title') != '':
+                    title = try_get(episode_data['TvDB'], 'Title')
 
                 episode_obj.title = title
 
                 Log('Episode Title: %s', episode_obj.title)
 
                 # Get description
-                if try_get(ep_data['anidb'], 'Description') != '':
-                    episode_obj.summary = summary_sanitizer(try_get(ep_data['anidb'], 'Description'))
+                if try_get(episode_data['AniDB'], 'Description') != '':
+                    episode_obj.summary = summary_sanitizer(try_get(episode_data['AniDB'], 'Description'))
                     Log('Description (AniDB): %s' % episode_obj.summary)
-                elif ep_data['tvdb'] and try_get(ep_data['tvdb'], 'Description') != None: 
-                    episode_obj.summary = summary_sanitizer(try_get(ep_data['tvdb'], 'Description'))
+                elif episode_data['TvDB'] and try_get(episode_data['TvDB'], 'Description') != None: 
+                    episode_obj.summary = summary_sanitizer(try_get(episode_data['TvDB'], 'Description'))
                     Log('Description (TvDB): %s' % episode_obj.summary)
 
                 # Get air date
-                airdate = try_get(ep_data['anidb'], 'AirDate', None)
+                airdate = try_get(episode_data['AniDB'], 'AirDate', None)
                 if airdate is not None:
                     episode_obj.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
 
                 if Prefs['customThumbs']:
-                   self.metadata_add(episode_obj.thumbs, [try_get(try_get(ep_data['tvdb'], 0, {}), 'Thumbnail', {})])
+                   self.metadata_add(episode_obj.thumbs, [try_get(try_get(episode_data['TvDB'], 0, {}), 'Thumbnail', {})])
 
                 # Get writers (as original work)
                 writers = HttpReq('api/v3/Series/%s/Cast?roleType=SourceWork' % aid) # http://127.0.0.1:8111/api/v3/Series/24/Cast?roleType=SourceWork
@@ -474,7 +461,7 @@ class ShokoCommonAgent:
 
             #adapted from: https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/fb5c77a60c925dcfd60e75a945244e07ee009e7c/Contents/Code/__init__.py#L41-L45
             if Prefs["themeMusic"]:
-                for tid in try_get(series_data['shoko']['IDs'],'TvDB', []):
+                for tid in try_get(series_data['IDs'],'TvDB', []):
                     if THEME_URL % tid not in metadata.themes:
                         try:
                             metadata.themes[THEME_URL % tid] = Proxy.Media(HTTP.Request(THEME_URL % tid))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -281,7 +281,7 @@ class ShokoCommonAgent:
         metadata.genres = tags
 
         # Get images
-        images = try_get(series_data 'Images', {})
+        images = try_get(series_data, 'Images', {})
         self.metadata_add(metadata.banners, try_get(images, 'Banners', []))
         self.metadata_add(metadata.posters, try_get(images, 'Posters', []))
         self.metadata_add(metadata.art, try_get(images, 'Fanarts', []))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -352,7 +352,7 @@ class ShokoCommonAgent:
             # Get episode list using series ID
             episodes = HttpReq('api/v3/Series/%s/Episode' % aid) # http://127.0.0.1:8111/api/v3/Series/212/Episode
 
-            for episode in episodes:
+            for episode in episodes['List']:
                 # Get episode data
                 ep_id = episode['IDs']['ID']
                 ep_data = {}

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -117,7 +117,7 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
+                    title = try_get(ep_titles, lang.lower(), None)
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                 full_title = series_data['shoko']['Name'] + ' - ' + title
@@ -161,7 +161,7 @@ class ShokoCommonAgent:
                         title = None
                         for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                             lang = lang.strip()
-                            if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
+                            title = try_get(ep_titles, lang.lower(), None)
                             if title is not None: break
                         if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                         full_title = series_data['shoko']['Name'] + ' - ' + title
@@ -237,7 +237,7 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
+                    title = try_get(ep_titles, lang.lower(), None)
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                 movie_name = series_data['shoko']['Name'] + ' - ' + title
@@ -390,7 +390,7 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    if lang.lower() in ep_titles: title = ep_titles[lang.lower()]
+                    title = try_get(ep_titles, lang.lower(), None)
                     if title is not None: break
                 if title is None: title = ep_titles['en'] # If not found, fallback to EN title
 
@@ -406,11 +406,11 @@ class ShokoCommonAgent:
                     singleTitle = title
                     for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                         lang = lang.strip()                                   
-                        if lang.lower() in series_titles: title = series_titles[lang.lower()]
+                        title = try_get(series_titles, lang.lower(), title)
                         if title is not singleTitle: break
-                    if title is singleTitle:
-                        if 'en' in series_titles: title = series_titles['en'] # If not found, fallback to EN series title
-                    else: # Fallback to TvDB title as a last resort
+                    if title is singleTitle: # If not found, fallback to EN series title
+                        title = try_get(series_titles, 'en', title)
+                    if title is singleTitle: # Fallback to TvDB title as a last resort
                         if try_get(ep_data['tvdb'], 'Title') != '': title = try_get(ep_data['tvdb'], 'Title')
 
                 # TvDB episode title fallback

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -92,6 +92,11 @@ class ShokoCommonAgent:
                     Log('File search has more than 1 result. HOW DID YOU DO IT?')
                 file_data = file_data[0]
 
+                # Ignore unrecognized files
+                if 'SeriesIDs' not in file_data or file_data['SeriesIDs'] is None:
+                    Log('Unrecognized file. Skipping!')
+                    return
+
                 # Get series data
                 series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
                 series_data = {}

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -123,8 +123,8 @@ class ShokoCommonAgent:
                 full_title = series_data['shoko']['Name'] + ' - ' + title
 
                 # Get year from air date
-                airdate = try_get(ep_data['anidb'], 'AirDate', '0001-01-01')
-                year = airdate.split('-')[0] if airdate != '0001-01-01' else None
+                airdate = try_get(ep_data['anidb'], 'AirDate', None)
+                year = airdate.split('-')[0] if airdate is not None else None
 
                 score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
 
@@ -167,8 +167,8 @@ class ShokoCommonAgent:
                         full_title = series_data['shoko']['Name'] + ' - ' + title
 
                         # Get year from air date
-                        airdate = try_get(ep_data['anidb'], 'AirDate', '0001-01-01')
-                        year = airdate.split('-')[0] if airdate != '0001-01-01' else None
+                        airdate = try_get(ep_data['anidb'], 'AirDate', None)
+                        year = airdate.split('-')[0] if airdate is not None else None
 
                         if title == name: score = 100 # Check if full name matches (Series name + episode name)
                         elif result['Name'] == name: score = 90 # Check if series name matches
@@ -189,8 +189,8 @@ class ShokoCommonAgent:
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id)
 
                 # Get year from air date
-                airdate = try_get(series_data['anidb'], 'AirDate', '0001-01-01')
-                year = airdate.split('-')[0] if airdate != '0001-01-01' else None
+                airdate = try_get(series_data['anidb'], 'AirDate', None)
+                year = airdate.split('-')[0] if airdate is not None else None
 
                 score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
 
@@ -251,8 +251,8 @@ class ShokoCommonAgent:
             metadata.rating = float(ep_data['anidb']['Rating']['Value']/100)
             
             # Get year from air date
-            airdate = try_get(ep_data['anidb'], 'AirDate', '0001-01-01')
-            if airdate != '0001-01-01':
+            airdate = try_get(ep_data['anidb'], 'AirDate', None)
+            if airdate is not None:
                 metadata.year = int(airdate.split('-')[0])
                 metadata.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -246,14 +246,10 @@ class ShokoCommonAgent:
             metadata.rating = float(ep_data['anidb']['Rating']['Value']/100)
             
             # Get year from air date
-            air_date = try_get(ep_data['anidb'], 'AirDate', None)
-            year = air_date.split('-')[0] if air_date is not None else None
-
-            if year:
-                metadata.year = int(year)
-
-            if air_date is not None:
-                metadata.originally_available_at = datetime.strptime(air_date, '%Y-%m-%d').date()
+            airdate = try_get(ep_data['anidb'], 'AirDate', '0001-01-01')
+            if airdate != '0001-01-01':
+                metadata.year = int(airdate.split('-')[0])
+                metadata.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
 
             collections = []
             if series_data['shoko']['Size'] > 1:
@@ -272,9 +268,9 @@ class ShokoCommonAgent:
             metadata.rating = float(series_data['anidb']['Rating']['Value']/100)
 
             # Get air date
-            air_date = try_get(series_data['anidb'], 'AirDate', None)
-            if air_date is not None:
-                metadata.originally_available_at = datetime.strptime(air_date, '%Y-%m-%d').date()
+            airdate = try_get(series_data['anidb'], 'AirDate', '0001-01-01')
+            if airdate != '0001-01-01':
+                metadata.originally_available_at = datetime.strptime(airdate, '%Y-%m-%d').date()
 
         # Get series tags
         series_tags = HttpReq('api/v3/Series/%s/Tags/%d' % (aid, flags)) # http://127.0.0.1:8111/api/v3/Series/24/Tags/0

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -58,7 +58,7 @@ def HttpReq(url, authenticate=True, retry=True):
     Log("Requesting: %s" % url)
 
     if authenticate:
-        myheaders['apikey'] = GetApiKey()
+        myheaders = {'apikey': GetApiKey()}
 
     try:
         return JSON.ObjectFromString(
@@ -412,10 +412,10 @@ class ShokoCommonAgent:
                 url = 'http://{host}:{port}{relativeURL}'.format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=art_url)
                 idx = try_get(art, 'index', 0)
                 Log("[metadata_add] :: Adding metadata %s (index %d)" % (url, idx))
-                meta[art['url']] = Proxy.Media(HTTP.Request(url).content, idx)
-                valid.append(art['url'])
+                meta[url] = Proxy.Media(HTTP.Request(url).content, idx)
+                valid.append(url)
             except Exception as e:
-                Log("[metadata_add] :: Invalid URL given (%s), skipping" % art['url'])
+                Log("[metadata_add] :: Invalid URL given (%s), skipping" % url)
                 Log(e)
 
         meta.validate_keys(valid)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -356,9 +356,10 @@ class ShokoCommonAgent:
                 # Get episode data
                 ep_id = episode['IDs']['ID']
                 ep_data = {}
-                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id)
-                ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id)
+                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+                ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
 
+                # Get episode type
                 ep_type = ep_data['anidb']['Type']
 
                 # Get season number

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -138,7 +138,7 @@ class ShokoCommonAgent:
                 Log('Searching movie %s' % name)
 
                 # Search for series using the name
-                prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
+                prelimresults = HttpReq('api/v3/Series/Search?query=%s&fuzzy=%s&limit=10' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search?query=Clannad&fuzzy=true&limit=10
 
                 for result in prelimresults:
                     # Get episode list using series ID
@@ -181,7 +181,7 @@ class ShokoCommonAgent:
 
         else:
             # Search for series using the name
-            prelimresults = HttpReq('api/v3/Series/Search/%s?fuzzy=%s' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search/Clannad?fuzzy=true
+            prelimresults = HttpReq('api/v3/Series/Search?query=%s&fuzzy=%s&limit=10' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search?query=Clannad&fuzzy=true&limit=10
 
             for result in prelimresults:
                 # Get series data

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -361,6 +361,7 @@ class ShokoCommonAgent:
 
                 # Get season number
                 season = 0
+                episode_number = None
                 if ep_type == 'Normal': season = 1
                 elif ep_type == 'Special': season = 0
                 elif ep_type == 'ThemeSong': season = -1
@@ -370,11 +371,15 @@ class ShokoCommonAgent:
                 if not Prefs['SingleSeasonOrdering'] and len(ep_data['tvdb']) != 0:
                     ep_data['tvdb'] = ep_data['tvdb'][0] # Take the first link, as explained before
                     season = ep_data['tvdb']['Season']
+                    episode_number = ep_data['tvdb']['Number']
+
+                if episode_number is None:
+                    episode_number = ep_data['anidb']['EpisodeNumber']
 
                 Log('Season: %s', season)
-                Log('Episode: %s', ep_data['anidb']['EpisodeNumber'])
+                Log('Episode: %s', episode_number)
 
-                episode_obj = metadata.seasons[season].episodes[ep_data['anidb']['EpisodeNumber']]
+                episode_obj = metadata.seasons[season].episodes[episode_number]
 
                 # Make a dict of language -> title for all titles in anidb data
                 ep_titles = {}

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -88,6 +88,9 @@ class ShokoCommonAgent:
                 # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
                 if len(file_data) > 1:
                     Log('File search has more than 1 result. HOW DID YOU DO IT?')
+                    Log('Unsupported! Skipping...')
+                    return
+
                 file_data = file_data[0]
 
                 # Ignore unrecognized files

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -14,15 +14,6 @@ from lxml import etree
 API_KEY = ''
 PLEX_HOST = ''
 
-EpisodeType = {
-    'Episode': 1,
-    'Credits': 2,
-    'Special': 3,
-    'Trailer': 4,
-    'Parody': 5,
-    'Other': 6
-}
-
 #this is from https://github.com/plexinc-agents/PlexThemeMusic.bundle/blob/master/Contents/Code/__init__.py
 THEME_URL = 'http://tvthemes.plexapp.com/%s.mp3'
 LINK_REGEX = r"https?:\/\/\w+.\w+(?:\/?\w+)? \[([^\]]+)\]"
@@ -121,9 +112,9 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = ep_titles[lang.upper()]
+                    title = ep_titles[lang.lower()]
                     if title is not None: break
-                if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                 full_title = series_data['shoko']['Name'] + ' - ' + title
 
                 # Get year from air date
@@ -165,9 +156,9 @@ class ShokoCommonAgent:
                         title = None
                         for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                             lang = lang.strip()
-                            title = ep_titles[lang.upper()]
+                            title = ep_titles[lang.lower()]
                             if title is not None: break
-                        if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                        if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                         full_title = series_data['shoko']['Name'] + ' - ' + title
 
                         # Get year from air date
@@ -232,7 +223,7 @@ class ShokoCommonAgent:
             for item in ep_data['anidb']['Titles']:
                 ep_titles[item['Language']] = item['Name']
 
-            title = try_get(ep_titles, 'EN', None)
+            title = try_get(ep_titles, 'en', None)
             if title in ['Complete Movie', 'Web']:
                 movie_name = series_data['anidb']['Name']
                 movie_sort_name = series_data['anidb']['Name']
@@ -241,9 +232,9 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = ep_titles[lang.upper()]
+                    title = ep_titles[lang.lower()]
                     if title is not None: break
-                if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                 movie_name = series_data['shoko']['Name'] + ' - ' + title
                 movie_sort_name = series_data['shoko']['Name'] + ' - ' + str(ep_data['anidb']['EpisodeNumber']).zfill(3)
 
@@ -352,20 +343,20 @@ class ShokoCommonAgent:
                 ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id)
 
                 ep_type = ep_data['anidb']['Type']
-                if ep_type not in [1, 3, 2, 4]: # Episode, Special, Credits, Trailer
+                if ep_type in ['Unknown', 'Parody']:
                     continue
 
                 # Get season number
                 season = 0
-                if ep_type == EpisodeType['Episode']: season = 1
-                elif ep_type == EpisodeType['Special']: season = 0
-                elif ep_type == EpisodeType['Credits']: season = -1
-                elif ep_type == EpisodeType['Trailer']: season = -2
+                if ep_type == 'Normal': season = 1
+                elif ep_type == 'Special': season = 0
+                elif ep_type == 'ThemeSong': season = -1
+                elif ep_type == 'Trailer': season = -2
                 if not Prefs['SingleSeasonOrdering'] and len(ep_data['tvdb']) != 0:
                     ep_data['tvdb'] = ep_data['tvdb'][0] # Take the first link, as explained before
                     season = ep_data['tvdb']['Season']
-                    if season <= 0 and ep_type == EpisodeType['Episode']: season = 1
-                    elif season > 0 and ep_type == EpisodeType['Special']: season = 0
+                    if season <= 0 and ep_type == 'Normal': season = 1
+                    elif season > 0 and ep_type == 'Special': season = 0
 
                 Log('Season: %s', season)
                 Log('Episode: %s', ep_data['anidb']['EpisodeNumber'])
@@ -381,9 +372,9 @@ class ShokoCommonAgent:
                 title = None
                 for lang in Prefs['EpisodeTitleLanguagePreference'].split(','):
                     lang = lang.strip()
-                    title = ep_titles[lang.upper()]
+                    title = ep_titles[lang.lower()]
                     if title is not None: break
-                if title is None: title = ep_titles['EN'] # If not found, fallback to EN title
+                if title is None: title = ep_titles['en'] # If not found, fallback to EN title
                 episode_obj.title = title
 
                 Log('Episode Title: %s', episode_obj.title)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -183,7 +183,7 @@ class ShokoCommonAgent:
             # Search for series using the name
             prelimresults = HttpReq('api/v3/Series/Search?query=%s&fuzzy=%s&limit=10' % (urllib.quote_plus(name.encode('utf8')), Prefs['Fuzzy'])) # http://127.0.0.1:8111/api/v3/Series/Search?query=Clannad&fuzzy=true&limit=10
 
-            for result in prelimresults:
+            for index, result in enumerate(prelimresults):
                 # Get series data
                 series_id = result['IDs']['ID']
                 series_data = {}
@@ -194,7 +194,7 @@ class ShokoCommonAgent:
                 airdate = try_get(series_data['anidb'], 'AirDate', None)
                 year = airdate.split('-')[0] if airdate is not None else None
 
-                score = 100 if series_data['shoko']['Name'] == name else 100 - int(result['Distance'] * 100) # TODO: Improve this to respect synonyms./
+                score = 100 if series_data['shoko']['Name'] == name else 100 - index - int(result['Distance'] * 100)
 
                 meta = MetadataSearchResult(str(series_id), series_data['shoko']['Name'], year, score, lang)
                 results.Append(meta)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -288,7 +288,7 @@ class ShokoCommonAgent:
                     series_titles[item['Language']] = item['Name']
             series_titles['shoko'] = series_data['Name']
 
-            # Get original title according to the preference
+            # Get series title according to the preference
             title = None
             for lang in Prefs['SeriesTitleLanguagePreference'].split(','):
                 lang = lang.strip()

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -403,7 +403,7 @@ class ShokoCommonAgent:
                         series_titles[item['Language']] = item['Name']
                                    
                     title = series_titles[lang.lower()] # Get series title according to the preference above
-                    if title is None: title = ep_titles['en'] # If not found, fallback to EN series title
+                    if title is None: title = series_titles['en'] # If not found, fallback to EN series title
 
                 # TvDB episode title fallback
                 if title.startswith('Episode ') and try_get(ep_data['tvdb'], 'Title') != '':

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -37,6 +37,13 @@
     },
 
     {
+        "id": "EpisodeTitleLanguagePreference",
+        "label": "The preferred languages for episode titles, separated by a comma",
+        "type": "text",
+        "default": "EN, X-JAT"
+    },
+
+    {
         "id": "Fuzzy",
         "label": "Use fuzzy searching in Shoko for matching the titles.",
         "type": "bool",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -37,10 +37,10 @@
     },
 
     {
-        "id": "OriginalTitleLanguagePreference",
-        "label": "The preferred languages for the original series title, separated by a comma",
+        "id": "SeriesTitleLanguagePreference",
+        "label": "The preferred languages for the series title, separated by a comma",
         "type": "text",
-        "default": "EN, X-JAT"
+        "default": "SHOKO, EN, X-JAT"
     },
 
     {

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -31,7 +31,7 @@
 
     {
         "id": "SingleSeasonOrdering",
-        "label": "Use single season ordering (IMPORTANT: Make sure the setting in scanner matches with this!)",
+        "label": "Use single season ordering (IMPORTANT: Make sure the setting 'SingleSeasonOrdering' in 'Shoko Series Scanner.py' matches with this setting or the scanner may crash!)",
         "type": "bool",
         "default": false
     },

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -37,6 +37,13 @@
     },
 
     {
+        "id": "OriginalTitleLanguagePreference",
+        "label": "The preferred languages for the original series title, separated by a comma",
+        "type": "text",
+        "default": "EN, X-JAT"
+    },
+
+    {
         "id": "EpisodeTitleLanguagePreference",
         "label": "The preferred languages for episode titles, separated by a comma",
         "type": "text",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -44,6 +44,13 @@
     },
 
     {
+        "id": "SeriesAltTitleLanguagePreference",
+        "label": "The preferred languages for the series alt title, separated by a comma. Set to \"SHOKO\" to get preferred title",
+        "type": "text",
+        "default": "EN, X-JAT, SHOKO"
+    },
+
+    {
         "id": "EpisodeTitleLanguagePreference",
         "label": "The preferred languages for episode titles, separated by a comma",
         "type": "text",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -38,7 +38,7 @@
 
     {
         "id": "SeriesTitleLanguagePreference",
-        "label": "The preferred languages for the series title, separated by a comma",
+        "label": "The preferred languages for the series title, separated by a comma. Set to \"SHOKO\" to get preferred title",
         "type": "text",
         "default": "SHOKO, EN, X-JAT"
     },

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -47,7 +47,7 @@
         "id": "SeriesAltTitleLanguagePreference",
         "label": "The preferred languages for the series alt title, separated by a comma. Set to \"SHOKO\" to get preferred title",
         "type": "text",
-        "default": "EN, X-JAT, SHOKO"
+        "default": "X-JAT, EN, SHOKO"
     },
 
     {

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -130,7 +130,13 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     continue
 
                 # Get series data
-                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
+                series_ids = try_get(file_data['SeriesIDs'], 0, None)
+
+                if series_ids is None:
+                    Log.info('Unrecognized file. Skipping!')
+                    continue
+
+                series_id = series_ids['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
                 series_data = {}
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # # http://127.0.0.1:8111/api/v3/Series/24/AniDB

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -112,8 +112,8 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 Log.info('file: %s', file)
                 # Get file data using filename
                 # http://127.0.0.1:8111/api/v3/File/PathEndsWith/Clannad/%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
-                file = os.path.join(os.path.split(os.path.dirname(file))[-1], os.path.basename(file)) # Parent folder + file name
-                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(file)))
+                filename = os.path.join(os.path.split(os.path.dirname(file))[-1], os.path.basename(file)) # Parent folder + file name
+                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(filename)))
                 if len(file_data) == 0: continue # Skip if file data is not found
 
                 # Take the first file. As we are searching with both parent folder and filename, there should be only one result.

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -98,7 +98,7 @@ def GetApiKey():
 
 
 def Scan(path, files, mediaList, subdirs, language=None, root=None):
-    
+
     Log.debug('path: %s', path)
     Log.debug('files: %s', files)
 

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -116,6 +116,9 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
                 if len(file_data) > 1:
                     Log.info('File search has more than 1 result. HOW DID YOU DO IT?')
+                    Log.info('Unsupported! Skipping...')
+                    continue
+
                 file_data = file_data[0]
 
                 # Ignore unrecognized files

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -135,7 +135,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # # http://127.0.0.1:8111/api/v3/Series/24/AniDB
                 
-                if try_get(series_data['anidb'], 'SeriesType', -1) != 0:
+                if try_get(series_data['anidb'], 'SeriesType', '-1') != '0':
                     Log.info('It\'s not a movie. Skipping!')
                     continue
 

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -57,17 +57,11 @@ def HttpPost(url, postdata):
     return json.load(urllib2.urlopen(req, postdata))
 
 
-def HttpReq(url, authenticate=True, retry=True):
+def HttpReq(url, retry=True):
     global API_KEY
     Log.info("Requesting: %s", url)
-    api_string = ''
-    if authenticate:
-        api_string = '&apikey=%s' % GetApiKey()
 
-    myheaders = {'Accept': 'application/json'}
-    
-    if authenticate:
-        myheaders['apikey'] = GetApiKey()
+    myheaders = {'Accept': 'application/json', 'apikey': GetApiKey()}
     
     try:
         req = urllib2.Request('http://%s:%s/%s' % (Prefs['Hostname'], Prefs['Port'], url), headers=myheaders)
@@ -77,7 +71,7 @@ def HttpReq(url, authenticate=True, retry=True):
             raise e
 
         API_KEY = ''
-        return HttpReq(url, authenticate, False)
+        return HttpReq(url, False)
 
 
 def GetApiKey():

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -135,7 +135,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # # http://127.0.0.1:8111/api/v3/Series/24/AniDB
                 
-                if try_get(series_data['anidb'], 'SeriesType', '-1') != '0':
+                if try_get(series_data['anidb'], 'Type', 'Unknown') != 'Movie':
                     Log.info('It\'s not a movie. Skipping!')
                     continue
 

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -125,7 +125,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 file_data = file_data[0]
 
                 # Ignore unrecognized files
-                if 'SeriesIDs' not in file_data:
+                if 'SeriesIDs' not in file_data or file_data['SeriesIDs'] is None:
                     Log.info('Unrecognized file. Skipping!')
                     continue
 

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -66,8 +66,11 @@ def HttpReq(url, authenticate=True, retry=True):
 
     myheaders = {'Accept': 'application/json'}
     
+    if authenticate:
+        myheaders['apikey'] = GetApiKey()
+    
     try:
-        req = urllib2.Request('http://%s:%s/%s%s' % (Prefs['Hostname'], Prefs['Port'], url, api_string), headers=myheaders)
+        req = urllib2.Request('http://%s:%s/%s' % (Prefs['Hostname'], Prefs['Port'], url), headers=myheaders)
         return json.load(urllib2.urlopen(req))
     except Exception, e:
         if not retry:

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -139,7 +139,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     Log.info('It\'s not a movie. Skipping!')
                     continue
 
-                # Get preferred/overriden title. Preferred title is the one shown in Desktop.
+                # Get preferred/overridden title. Preferred title is the one shown in Desktop.
                 show_title = series_data['shoko']['Name'].encode('utf-8') #no idea why I need to do this.
                 Log.info('Show Title: %s', show_title)
 

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -134,6 +134,10 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 series_data = {}
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # # http://127.0.0.1:8111/api/v3/Series/24/AniDB
+                
+                if try_get(series_data['anidb'], 'SeriesType', -1) != 0:
+                    Log.info('It\'s not a movie. Skipping!')
+                    continue
 
                 # Get preferred/overriden title. Preferred title is the one shown in Desktop.
                 show_title = series_data['shoko']['Name'].encode('utf-8') #no idea why I need to do this.

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -144,9 +144,20 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 Log.info('Show Title: %s', show_title)
 
                 # Get episode data
-                ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][0]['ID'] # Taking the first link, again
-                ep_data = {}
-                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+                series_ids = try_get(file_data['SeriesIDs'], 0, None)
+
+                if series_ids is None:
+                    Log.info('Unrecognized file. Skipping!')
+                    continue
+
+                ep_ids = try_get(series_ids['EpisodeIDs'], 0, None)
+
+                if series_ids is None:
+                    Log.info('Unrecognized file. Skipping!')
+                    continue
+
+                ep_id = ep_ids['ID'] # Taking the first link, again
+                ep_data = {'anidb': HttpReq('api/v3/Episode/%s/AniDB' % ep_id)}
 
                 # Get year from air date
                 air_date = try_get(ep_data['anidb'], 'AirDate', None)

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -130,7 +130,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     continue
 
                 # Get series data
-                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
+                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
                 series_data = {}
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # # http://127.0.0.1:8111/api/v3/Series/24/AniDB

--- a/Contents/Resources/Movies/Shoko Movie Scanner.py
+++ b/Contents/Resources/Movies/Shoko Movie Scanner.py
@@ -131,16 +131,14 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     continue
 
                 series_id = series_ids['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
-                series_data = {}
-                series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
-                series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # # http://127.0.0.1:8111/api/v3/Series/24/AniDB
+                series_data = HttpReq('api/v3/Series/%s?includeDataFrom=AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24?includeDataFrom=AniDB
                 
-                if try_get(series_data['anidb'], 'Type', 'Unknown') != 'Movie':
+                if try_get(series_data['AniDB'], 'Type', 'Unknown') != 'Movie':
                     Log.info('It\'s not a movie. Skipping!')
                     continue
 
                 # Get preferred/overridden title. Preferred title is the one shown in Desktop.
-                show_title = series_data['shoko']['Name'].encode('utf-8') #no idea why I need to do this.
+                show_title = series_data['Name'].encode('utf-8') #no idea why I need to do this.
                 Log.info('Show Title: %s', show_title)
 
                 # Get episode data
@@ -150,17 +148,17 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     Log.info('Unrecognized file. Skipping!')
                     continue
 
-                ep_ids = try_get(series_ids['EpisodeIDs'], 0, None)
+                episode_ids = try_get(series_ids['EpisodeIDs'], 0, None)
 
                 if series_ids is None:
                     Log.info('Unrecognized file. Skipping!')
                     continue
 
-                ep_id = ep_ids['ID'] # Taking the first link, again
-                ep_data = {'anidb': HttpReq('api/v3/Episode/%s/AniDB' % ep_id)}
+                episode_id = episode_ids['ID'] # Taking the first link, again
+                anidb_episode_data = HttpReq('api/v3/Episode/%s/AniDB' % episode_id)
 
                 # Get year from air date
-                air_date = try_get(ep_data['anidb'], 'AirDate', None)
+                air_date = try_get(anidb_episode_data, 'AirDate', None)
                 season_year = air_date.split('-')[0] if air_date is not None else None
                 Log.info('season year: %s', season_year)
 

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -128,7 +128,13 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     continue
 
                 # Get series data
-                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
+                series_ids = try_get(file_data['SeriesIDs'], 0, None)
+
+                if series_ids is None:
+                    Log.info('Unrecognized file. Skipping!')
+                    continue
+
+                series_id = series_ids['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
                 series_data = {}
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -60,17 +60,11 @@ def HttpPost(url, postdata):
     return json.load(urllib2.urlopen(req, postdata))
 
 
-def HttpReq(url, authenticate=True, retry=True):
+def HttpReq(url, retry=True):
     global API_KEY
     Log.info("Requesting: %s", url)
-    api_string = ''
-    if authenticate:
-        api_string = '&apikey=%s' % GetApiKey()
 
-    myheaders = {'Accept': 'application/json'}
-    
-    if authenticate:
-        myheaders['apikey'] = GetApiKey()
+    myheaders = {'Accept': 'application/json', 'apikey': GetApiKey()}
     
     try:
         req = urllib2.Request('http://%s:%s/%s' % (Prefs['Hostname'], Prefs['Port'], url), headers=myheaders)
@@ -80,7 +74,7 @@ def HttpReq(url, authenticate=True, retry=True):
             raise e
 
         API_KEY = ''
-        return HttpReq(url, authenticate, False)
+        return HttpReq(url, False)
 
 
 def GetApiKey():

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -129,7 +129,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 file_data = file_data[0]
                 
                 # Ignore unrecognized files
-                if 'SeriesIDs' not in file_data:
+                if 'SeriesIDs' not in file_data or file_data['SeriesIDs'] is None:
                     Log.info('Unrecognized file. Skipping!')
                     continue
 

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -174,7 +174,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
 
                 Log.info('Season: %s', season)
 
-                if ep_data['tvdb'] is not None:
+                if ep_data['tvdb'] is not None and not Prefs['SingleSeasonOrdering']:
                     episode_number = ep_data['tvdb']['Number']
                 else:
                     episode_number = ep_data['anidb']['EpisodeNumber']

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -15,6 +15,15 @@ Prefs = {
 
 API_KEY = ''
 
+EpisodeType = {
+    'Episode': 1,
+    'Credits': 2,
+    'Special': 3,
+    'Trailer': 4,
+    'Parody': 5,
+    'Other': 6
+}
+
 ### Log + LOG_PATH calculated once for all calls ###
 import logging, logging.handlers                        #
 RootLogger     = logging.getLogger('main')
@@ -69,8 +78,11 @@ def HttpReq(url, authenticate=True, retry=True):
 
     myheaders = {'Accept': 'application/json'}
     
+    if authenticate:
+        myheaders['apikey'] = GetApiKey()
+    
     try:
-        req = urllib2.Request('http://%s:%s/%s%s' % (Prefs['Hostname'], Prefs['Port'], url, api_string), headers=myheaders)
+        req = urllib2.Request('http://%s:%s/%s' % (Prefs['Hostname'], Prefs['Port'], url), headers=myheaders)
         return json.load(urllib2.urlopen(req))
     except Exception, e:
         if not retry:
@@ -84,8 +96,11 @@ def GetApiKey():
     global API_KEY
 
     if not API_KEY:
-        data = '{"user":"%s", "pass":"%s", "device":"%s"}' % (
-            Prefs['Username'], Prefs['Password'] if Prefs['Password'] != None else '', 'Shoko Series Scanner For Plex')
+        data = json.dumps({
+            'user': Prefs['Username'],
+            'pass': Prefs['Password'] if Prefs['Password'] != None else '',
+            'device': 'Shoko Series Scanner For Plex'
+        })
         resp = HttpPost('api/auth', data)['apikey']
         Log.info( "Got API KEY: %s", resp)
         API_KEY = resp
@@ -111,35 +126,67 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 Log.info('file: %s', file)
                 # http://127.0.0.1:8111/api/ep/getbyfilename?apikey=d422dfd2-bdc3-4219-b3bb-08b85aa65579&filename=%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
 
-                episode_data = HttpReq("api/ep/getbyfilename?filename=%s" % (urllib.quote(os.path.basename(file))))
-                if len(episode_data) == 0: continue
-                if (try_get(episode_data, "code", 200) == 404): continue
+                # Get file data using filename
+                # http://127.0.0.1:8111/api/v3/File/PathEndsWith/Clannad/%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
+                file = os.path.join(os.path.split(os.path.dirname(file))[-1], os.path.basename(file)) # Parent folder + file name
+                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(file)))
+                if len(file_data) == 0: continue # Skip if file data is not found
 
-                series_data = HttpReq("api/serie/fromep?id=%d&nocast=1&notag=1" % episode_data['id'])
-                showTitle = series_data['name'].encode("utf-8") #no idea why I need to do this.
-                Log.info('show title: %s', showTitle)
+                # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
+                if len(file_data) > 1:
+                    Log.info('File search has more than 1 result. HOW DID YOU DO IT?')
+                file_data = file_data[0]
+                
+                # Ignore unrecognized files
+                if 'SeriesIDs' not in file_data:
+                    Log.info('Unrecognized file. Skipping!')
+                    continue
 
-                seasonNumber = 0
-                seasonStr = try_get(episode_data, 'season', None)
-                if episode_data['eptype'] == 'Credits': seasonNumber = -1 #season -1 for OP/ED
-                elif episode_data['eptype'] == 'Trailer': seasonNumber = -2 #season -2 for Trailer
-                elif Prefs['SingleSeasonOrdering'] or seasonStr == None:
-                    if episode_data['eptype'] == 'Episode': seasonNumber = 1
-                    elif episode_data['eptype'] == 'Special': seasonNumber = 0
-                else:
-                    seasonNumber = int(seasonStr.split('x')[0])
-                    if seasonNumber <= 0 and episode_data['eptype'] == 'Episode': seasonNumber = 1
-                    elif seasonNumber > 0 and episode_data['eptype'] == 'Special': seasonNumber = 0
+                # Get series data
+                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
+                series_data = {}
+                series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
+                series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
-                if seasonNumber == 0 and Prefs['IncludeSpecials'] == False: continue
-                if seasonNumber < 0 and Prefs['IncludeOther'] == False: continue #Ignore this by choice.
+                # Get preferred/overriden title. Preferred title is the one shown in Desktop.
+                show_title = series_data['shoko']['Name'].encode('utf-8') #no idea why I need to do this.
+                Log.info('Show Title: %s', show_title)
 
-                if (try_get(series_data, "ismovie", 0) == 1 and seasonNumber >= 1): continue # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
-                Log.info('season number: %s', seasonNumber)
-                episodeNumber = int(episode_data['epnumber'])
-                Log.info('episode number: %s', episodeNumber)
+                # Get episode data
+                ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][0]['ID'] # Taking the first link, again
+                ep_data = {}
+                ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
 
-                vid = Media.Episode(showTitle, seasonNumber, episodeNumber)
+                # Get season number
+                ep_type = ep_data['anidb']['Type']
+                season = 0
+                if ep_type == EpisodeType['Episode']: season = 1
+                elif ep_type == EpisodeType['Special']: season = 0
+                elif ep_type == EpisodeType['Credits']: season = -1
+                elif ep_type == EpisodeType['Trailer']: season = -2
+                if not Prefs['SingleSeasonOrdering']:
+                    ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
+                    ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before
+                    if ep_data['tvdb'] is not None:
+                        season = ep_data['tvdb']['Season']
+                        if season <= 0 and ep_type == EpisodeType['Episode']: season = 1
+                        elif season > 0 and ep_type == EpisodeType['Special']: season = 0
+
+                # Ignore these by choice.
+                if season == 0 and Prefs['IncludeSpecials'] == False: continue
+                if season < 0 and Prefs['IncludeOther'] == False: continue
+
+                # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
+                if (try_get(series_data['anidb'], 'SeriesType', -1) == 0 and season >= 1):
+                    Log.info('It\'s a movie. Skipping!')
+                    continue
+
+                Log.info('Season: %s', season)
+
+                episode_number = ep_data['anidb']['EpisodeNumber']
+                Log.info('Episode Number: %s', episode_number)
+
+                vid = Media.Episode(show_title, season, episode_number)
                 Log.info('vid: %s', vid)
                 vid.parts.append(file)
                 mediaList.append(vid)

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -139,7 +139,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB
 
-                # Get preferred/overriden title. Preferred title is the one shown in Desktop.
+                # Get preferred/overridden title. Preferred title is the one shown in Desktop.
                 show_title = series_data['shoko']['Name'].encode('utf-8') #no idea why I need to do this.
                 Log.info('Show Title: %s', show_title)
 

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -163,8 +163,6 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before
                     if ep_data['tvdb'] is not None:
                         season = ep_data['tvdb']['Season']
-                        if season <= 0 and ep_type == 'Normal': season = 1
-                        elif season > 0 and ep_type == 'Special': season = 0
 
                 # Ignore these by choice.
                 if season == 0 and Prefs['IncludeSpecials'] == False: continue

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -149,9 +149,15 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     ep_id = file_data['SeriesIDs'][0]['EpisodeIDs'][ep]['ID']
                     ep_data = {}
                     ep_data['anidb'] = HttpReq('api/v3/Episode/%s/AniDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/AniDB
+                    ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
+                    
+                    # Get episode type
+                    ep_type = ep_data['anidb']['Type']
+
+                    # Ignore multi episode files of differing types (anidb episode relations)
+                    if ep > 0 and ep_type != ep_data['anidb']['Type']: continue
 
                     # Get season number
-                    ep_type = ep_data['anidb']['Type']
                     season = 0
                     if ep_type == 'Normal': season = 1
                     elif ep_type == 'Special': season = 0
@@ -160,7 +166,6 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     elif ep_type == 'Parody': season = -3
                     elif ep_type == 'Unknown': season = -4
                     if not Prefs['SingleSeasonOrdering']:
-                        ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
                         ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before
                         if ep_data['tvdb'] is not None:
                             season = ep_data['tvdb']['Season']
@@ -176,7 +181,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
 
                     Log.info('Season: %s', season)
 
-                    if ep_data['tvdb'] is not None and not Prefs['SingleSeasonOrdering']:
+                    if not Prefs['SingleSeasonOrdering'] and ep_data['tvdb'] is not None:
                         episode_number = ep_data['tvdb']['Number']
                     else:
                         episode_number = ep_data['anidb']['EpisodeNumber']

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -177,7 +177,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 if season < 0 and Prefs['IncludeOther'] == False: continue
 
                 # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
-                if (try_get(series_data['anidb'], 'SeriesType', -1) == 0 and season >= 1):
+                if (try_get(series_data['anidb'], 'SeriesType', '-1') == '0' and season >= 1):
                     Log.info('It\'s a movie. Skipping!')
                     continue
 

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -156,6 +156,8 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 elif ep_type == 'Special': season = 0
                 elif ep_type == 'ThemeSong': season = -1
                 elif ep_type == 'Trailer': season = -2
+                elif ep_type == 'Parody': season = -3
+                elif ep_type == 'Unknown': season = -4
                 if not Prefs['SingleSeasonOrdering']:
                     ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
                     ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -175,7 +175,11 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
 
                 Log.info('Season: %s', season)
 
-                episode_number = ep_data['anidb']['EpisodeNumber']
+                if ep_data['tvdb'] is not None:
+                    episode_number = ep_data['tvdb']['Number']
+                else:
+                    episode_number = ep_data['anidb']['EpisodeNumber']
+
                 Log.info('Episode Number: %s', episode_number)
 
                 vid = Media.Episode(show_title, season, episode_number)

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -119,6 +119,9 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 # Take the first file. As we are searching with both parent folder and filename, there should be only one result.
                 if len(file_data) > 1:
                     Log.info('File search has more than 1 result. HOW DID YOU DO IT?')
+                    Log.info('Unsupported! Skipping...')
+                    continue
+
                 file_data = file_data[0]
                 
                 # Ignore unrecognized files

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -10,7 +10,8 @@ Prefs = {
     'Password': '',
     'IncludeSpecials': True,
     'IncludeOther': False,
-    'SingleSeasonOrdering': False
+    'SingleSeasonOrdering': False,
+    'CombineSeriesAndMovies': False
 }
 
 API_KEY = ''
@@ -168,7 +169,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 if season < 0 and Prefs['IncludeOther'] == False: continue
 
                 # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
-                if (try_get(series_data['anidb'], 'Type', 'Unknown') == 'Movie' and season >= 1):
+                if (try_get(series_data['anidb'], 'Type', 'Unknown') == 'Movie' and season >= 1 and Prefs['CombineSeriesAndMovies'] == False):
                     Log.info('It\'s a movie. Skipping!')
                     continue
 

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -134,7 +134,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                     continue
 
                 # Get series data
-                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toradora/One Piece episodes
+                series_id = file_data['SeriesIDs'][0]['SeriesID']['ID'] # Taking the first matching anime. Not supporting multi-anime linked files for now. eg. Those two Toriko/One Piece episodes
                 series_data = {}
                 series_data['shoko'] = HttpReq('api/v3/Series/%s' % series_id) # http://127.0.0.1:8111/api/v3/Series/24
                 series_data['anidb'] = HttpReq('api/v3/Series/%s/AniDB' % series_id) # http://127.0.0.1:8111/api/v3/Series/24/AniDB

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -15,15 +15,6 @@ Prefs = {
 
 API_KEY = ''
 
-EpisodeType = {
-    'Episode': 1,
-    'Credits': 2,
-    'Special': 3,
-    'Trailer': 4,
-    'Parody': 5,
-    'Other': 6
-}
-
 ### Log + LOG_PATH calculated once for all calls ###
 import logging, logging.handlers                        #
 RootLogger     = logging.getLogger('main')
@@ -160,24 +151,24 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 # Get season number
                 ep_type = ep_data['anidb']['Type']
                 season = 0
-                if ep_type == EpisodeType['Episode']: season = 1
-                elif ep_type == EpisodeType['Special']: season = 0
-                elif ep_type == EpisodeType['Credits']: season = -1
-                elif ep_type == EpisodeType['Trailer']: season = -2
+                if ep_type == 'Normal': season = 1
+                elif ep_type == 'Special': season = 0
+                elif ep_type == 'ThemeSong': season = -1
+                elif ep_type == 'Trailer': season = -2
                 if not Prefs['SingleSeasonOrdering']:
                     ep_data['tvdb'] = HttpReq('api/v3/Episode/%s/TvDB' % ep_id) # http://127.0.0.1:8111/api/v3/Episode/212/TvDB
                     ep_data['tvdb'] = try_get(ep_data['tvdb'], 0, None) # Take the first link, as explained before
                     if ep_data['tvdb'] is not None:
                         season = ep_data['tvdb']['Season']
-                        if season <= 0 and ep_type == EpisodeType['Episode']: season = 1
-                        elif season > 0 and ep_type == EpisodeType['Special']: season = 0
+                        if season <= 0 and ep_type == 'Normal': season = 1
+                        elif season > 0 and ep_type == 'Special': season = 0
 
                 # Ignore these by choice.
                 if season == 0 and Prefs['IncludeSpecials'] == False: continue
                 if season < 0 and Prefs['IncludeOther'] == False: continue
 
                 # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
-                if (try_get(series_data['anidb'], 'SeriesType', '-1') == '0' and season >= 1):
+                if (try_get(series_data['anidb'], 'Type', 'Unknown') == 'Movie' and season >= 1):
                     Log.info('It\'s a movie. Skipping!')
                     continue
 

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -128,8 +128,8 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
 
                 # Get file data using filename
                 # http://127.0.0.1:8111/api/v3/File/PathEndsWith/Clannad/%5Bjoseole99%5D%20Clannad%20-%2001%20(1280x720%20Blu-ray%20H264)%20%5B8E128DF5%5D.mkv
-                file = os.path.join(os.path.split(os.path.dirname(file))[-1], os.path.basename(file)) # Parent folder + file name
-                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(file)))
+                filename = os.path.join(os.path.split(os.path.dirname(file))[-1], os.path.basename(file)) # Parent folder + file name
+                file_data = HttpReq('api/v3/File/PathEndsWith/%s' % (urllib.quote(filename)))
                 if len(file_data) == 0: continue # Skip if file data is not found
 
                 # Take the first file. As we are searching with both parent folder and filename, there should be only one result.

--- a/Contents/Resources/Series/Shoko Series Scanner.py
+++ b/Contents/Resources/Series/Shoko Series Scanner.py
@@ -10,8 +10,7 @@ Prefs = {
     'Password': '',
     'IncludeSpecials': True,
     'IncludeOther': False,
-    'SingleSeasonOrdering': False,
-    'CombineSeriesAndMovies': False
+    'SingleSeasonOrdering': False
 }
 
 API_KEY = ''
@@ -169,7 +168,7 @@ def Scan(path, files, mediaList, subdirs, language=None, root=None):
                 if season < 0 and Prefs['IncludeOther'] == False: continue
 
                 # Ignore movies in preference for Shoko Movie Scanner, but keep specials as Plex sees specials as duplicate
-                if (try_get(series_data['anidb'], 'Type', 'Unknown') == 'Movie' and season >= 1 and Prefs['CombineSeriesAndMovies'] == False):
+                if (try_get(series_data['anidb'], 'Type', 'Unknown') == 'Movie' and season >= 1):
                     Log.info('It\'s a movie. Skipping!')
                     continue
 


### PR DESCRIPTION
- Changed all endpoints to API v3
- API key is now added in headers instead of the URL
- Added subdirectories support to movie scanner also.
- Add preference for Episode Title Language

Changes by @natyusha
- Add fallback for studio name and support for writer and director names
- Change tag names to lowercase to account for inconsistent capitalization of tags
- Fixes 'Other' and 'Parody' files overlapping with specials.
- Added fallback for missing AniDB episode descriptions from the TvDB.
- Allows parody and other files to fetch episode data as that was disabled completely.
- Added custom names for negative seasons (metadata xml only).
- Fix seasons overlapping when merging seasons of shows with mostly specials.
- Add TvDB episode number support for shows that are matched in shoko.
- Fix episode numbers when merging seasons that are split on TvDB but a single entry on AniDB.
- Fallback for missing or ambiguous AniDB titles.
- Support for multi-episode files
- Bypass pagination since /api/v3/Series/{seriesID}/Episode endpoint now defaults to 20 results with pages which breaks episode matching past 20.
- v3 API Search results are now more consistent and work with synonyms so account for this by using the order of the results to impact the score in Plex. This is also required since the distance will always be 0 for API searches that contain the same words as the search.
- Exclude all short titles then use setdefault() to use the first title for each language. This avoids synonyms overriding the main title in the dict but still allows synonyms if there is no official title set.