### PR TITLE
Add studio information

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -221,6 +221,21 @@ class ShokoCommonAgent:
             meta_role.role = role['character']
             meta_role.photo = "http://{host}:{port}{relativeURL}".format(host=Prefs['Hostname'], port=Prefs['Port'], relativeURL=role['staff_image'])
 
+        # Add studio information
+        # Plex does not support multiple studios, we take the first studio found.
+        cast_v3 = HttpReq("api/v3/series/%s/Cast?" % aid)
+        for element in cast_v3:
+            if element['RoleName'] == "Studio":
+                metadata.studio = element['Staff']['Name']
+                break
+
+        # If there is no "Animation Work" on AniDB we use "Work"
+        if metadata.studio == None:
+            for element in cast_v3:
+                if element['RoleDetails'] == "Work":
+                    metadata.studio = element['Staff']['Name']
+                    break
+
 
         if not movie:
             for ep in series['eps']:


### PR DESCRIPTION
Hi,

I noticed that the api v3 of [ShokoServer](https://github.com/ShokoAnime/ShokoServer) contains information about the studio. They consider "Studio" what is marked as "Animation Work" on AniDB.

I modified the code so that this information can be added on Plex. Unfortunately Plex only supports one single studio, therefore I took the first one if multiple are available.

Sometimes "Animation Work" is not present on AniDB but the option "Work" is ([example](https://anidb.net/anime/8895)). In those cases I considered that information as the studio.

Let me know if I need to change something.