### PR TITLE
Use series rating if Complete Movie is provided.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -136,14 +136,16 @@ class ShokoCommonAgent:
             if movie_episode_data['name'] == 'Complete Movie':
                 movie_name = series['name']
                 movie_sort_name = series['name']
+                movie_rating = float(series['rating'])
             else:
                 movie_name = series['name'] + ' - ' + movie_episode_data['name']
                 movie_sort_name = series['name'] + ' - ' + str(movie_episode_data['epnumber']).zfill(3)
+                movie_rating = float(movie_episode_data['rating'])
 
             metadata.summary = summary_sanitizer(try_get(series, 'summary'))
             metadata.title = movie_name
             metadata.title_sort = movie_sort_name
-            metadata.rating = float(movie_episode_data['rating'])
+            metadata.rating = movie_rating
             year = try_get(movie_episode_data, "year", try_get(series, "year", None))
 
             if year:


### PR DESCRIPTION
This was a suggestion based on mohan226 feedback in Discord.

For movies, when the file provided is a "Complete Movie" entry on AniDB, currently the rating is obtained from the episode instead of getting it from the Anime Movie entry itself.

This will use the movie rating itself in this specific case.

Example:
Adding a file linked to the "Complete Movie" in https://anidb.net/anime/2097 will return the following rating:

![image](https://user-images.githubusercontent.com/14930057/191078282-fe7f98b3-6006-4b00-8f58-0b5eb05ce7d3.png)
